### PR TITLE
Added Options for Inverted Orientations

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -87,6 +87,8 @@
                         <select id="orientation" name="orientation" class="form-input">
                             <option value="horizontal" {% if device_settings.orientation == "horizontal" %}selected{% endif %}>Horizontal</option>
                             <option value="vertical" {% if device_settings.orientation == "vertical" %}selected{% endif %}>Vertical</option>
+                            <option value="horizontalinverted" {% if device_settings.orientation == "horizontalinverted" %}selected{% endif %}>Horizontal (Inverted)</option>
+                            <option value="verticalinverted" {% if device_settings.orientation == "verticalinverted" %}selected{% endif %}>Vertical (Inverted)</option>
                         </select>
                     </div>
                     

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -23,6 +23,10 @@ def change_orientation(image, orientation):
         image = image.rotate(0, expand=1)
     elif orientation == 'vertical':
         image = image.rotate(90, expand=1)
+    elif orientation == 'horizontalinverted':
+        image = image.rotate(180, expand=1)
+    elif orientation == 'verticalinverted':
+        image = image.rotate(270, expand=1)
     return image
 
 def resize_image(image, desired_size, image_settings=[]):


### PR DESCRIPTION
Simple update;

 - Added the ability to select an inverted version for each of the orientations allowing users to select the original rotation values of 0, 90 and now 180, 270
 
 I'm open to changing the display name or the setting value. Might be worth changing the settings values to degrees of rotation to make localization easier in the future.
![image](https://github.com/user-attachments/assets/0b4d40cf-724e-4367-b91c-656c3217437b)
