### PR TITLE
fix: add support for inky impressions 7.3 2025 edition

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -1,6 +1,6 @@
 flask==3.1.0
 python-dotenv==1.0.1
-inky==2.0.0
+inky==2.1.0
 requests==2.32.3
 urllib3==2.3.0
 werkzeug==3.1.3


### PR DESCRIPTION
Adds support for new spectra 6 e-ink displays from Inky Impressions