### PR TITLE
Add option to invert images

### DIFF
--- a/install/config_base/device.json
+++ b/install/config_base/device.json
@@ -1,6 +1,7 @@
 {
     "name": "InkyPi",
     "orientation": "horizontal",
+    "inverted_image": false,
     "scheduler_sleep_time": 60,
     "startup": true
 }

--- a/src/blueprints/settings.py
+++ b/src/blueprints/settings.py
@@ -31,6 +31,7 @@ def save_settings():
         settings = {
             "name": form_data.get("deviceName"),
             "orientation": form_data.get("orientation"),
+            "inverted_image": form_data.get("invertImage"),
             "timezone": form_data.get("timezoneName"),
             "plugin_cycle_interval_seconds": plugin_cycle_interval_seconds
         }

--- a/src/display_manager.py
+++ b/src/display_manager.py
@@ -24,7 +24,7 @@ class DisplayManager:
         image.save(self.device_config.current_image_file)
 
         # Resize and adjust orientation
-        image = change_orientation(image, self.device_config.get_config("orientation"))
+        image = change_orientation(image, self.device_config.get_config("orientation"), self.device_config.get_config("inverted_image"))
         image = resize_image(image, self.device_config.get_resolution(), image_settings)
 
         # Display the image on the Inky display

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -88,7 +88,11 @@
                             <option value="horizontal" {% if device_settings.orientation == "horizontal" %}selected{% endif %}>Horizontal</option>
                             <option value="vertical" {% if device_settings.orientation == "vertical" %}selected{% endif %}>Vertical</option>
                         </select>
-                    </div>
+                        <!-- Invert Image Checkbox -->
+                        <label class="form-label" for="invertImage">Invert Image</label>
+                        <input type="checkbox" id="invertImage" name="invertImage" {% if device_settings.inverted_image %}checked{% endif %}>
+                        </label>
+                </div>
                     
                     <!-- Timezone Dropdown -->
                     <div class="form-group">

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -18,12 +18,16 @@ def get_image(image_url):
         logger.error(f"Received non-200 response from {image_url}: status_code: {response.status_code}")
     return img
 
-def change_orientation(image, orientation):
+def change_orientation(image, orientation, inverted=False):
     if orientation == 'horizontal':
-        image = image.rotate(0, expand=1)
+        angle = 0
     elif orientation == 'vertical':
-        image = image.rotate(90, expand=1)
-    return image
+        angle = 90
+
+    if inverted:
+        angle = (angle + 180) % 360
+
+    return image.rotate(angle, expand=1)
 
 def resize_image(image, desired_size, image_settings=[]):
     img_width, img_height = image.size


### PR DESCRIPTION
I saw [Added Options for Inverted Orientations #59](https://github.com/fatihak/InkyPi/pull/59) and decided to implement the changes you requested.

It's now a checkbox next to the Orientation as per requested.
![image](https://github.com/user-attachments/assets/c288680e-e12f-4b7b-a670-8d9c544ac1f9)

This feature gives users the flexibility to use any frame or mounting position without worrying about the display orientation.

I went with `inverted_image` for the setting, I felt like it was the most descriptive option. I also updated `change_orientation` to support this, and made sure it defaults to `false`.
I tested it and it works on my end, but do feel free to test it yourself and share your thoughts. 

One thing to note: the preview remains upright, which makes sense in my opinion, but let me know what you think.

What's left: Adding this to the plugins and the plugin template, which I am happy to do after some feedback.