### PR TITLE
Add option for manual location name entry

### DIFF
--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -15,6 +15,22 @@
 </div>
 
 <div class="form-group">
+    <label class="form-label">Manual Location Name: </label>
+    <div class="form-group">
+        <input type="checkbox" id="enableName" name="enableName" onclick="this.value=this.checked ? 'true' : 'false';">
+        <span>Enable?</span>
+    </div>
+    <div class="form-group">
+        <span>City: </span>
+        <input type="text" id="cityName" name="cityName" class="form-input" />
+    </div>
+    <div class="form-group">
+        <span>State/Country: </span>
+        <input type="text" id="stateName" name="stateName" class="form-input" />
+    </div>
+</div>
+
+<div class="form-group">
     <label for="units" class="form-label">Units:</label>
     <select id="units" name="units" class="form-input">
         <option value="imperial">Imperial (°F)</option>

--- a/src/plugins/weather/weather.py
+++ b/src/plugins/weather/weather.py
@@ -57,7 +57,11 @@ class Weather(BasePlugin):
 
         weather_data = self.get_weather_data(api_key, units, lat, long)
         aqi_data = self.get_air_quality(api_key, lat, long)
-        location_data = self.get_location(api_key, lat, long)
+        # Check if manual name is enabled, create dict as needed in parsing of weather data. When enabled, avoids request to OpenWeather API for location
+        if settings.get('enableName'):
+            location_data = {'name': settings.get('cityName'), 'state': settings.get('stateName')}
+        else:
+            location_data = self.get_location(api_key, lat, long)
 
         dimensions = device_config.get_resolution()
         if device_config.get_config("orientation") == "vertical":


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3576c414-82fc-44f3-9f52-208fbd5982a6)
![current_image](https://github.com/user-attachments/assets/b265601a-9d8f-423f-8337-cfebaf52c1ce)

This feature gives users the ability to manually assign a city and State/Country name, if desired. For my specific location, I get a rather generic name when using the OpenWeather API location based on my lat/long (county name, state). 

Having the ability to manually enter a location makes the presentation better.

Code is written to bypass OpenWeather location API call if manually entry is desired.