### PR TITLE
fix ai_text setting validation

### DIFF
--- a/src/plugins/ai_text/ai_text.py
+++ b/src/plugins/ai_text/ai_text.py
@@ -35,7 +35,7 @@ class AIText(BasePlugin):
             raise RuntimeError("Text Model is required.")
 
         text_prompt = settings.get('textPrompt', '')
-        if not text_model.strip():
+        if not text_prompt.strip():
             raise RuntimeError("Text Prompt is required.")
 
         try:


### PR DESCRIPTION
the validation of the presence of a prompt in the **ai text** plugin was referencing the wrong variable