### PR TITLE
Weather: add a margin setting for each side

### DIFF
--- a/src/plugins/base_plugin/render/plugin.html
+++ b/src/plugins/base_plugin/render/plugin.html
@@ -28,10 +28,25 @@
             background-position: center;
         {% endif %}
         color: {{ plugin_settings.textColor }};
-        {% if plugin_settings.margin %}
-            margin: {{ plugin_settings.margin }}px;
+        {% if plugin_settings.topMargin %}
+            margin-top: {{ plugin_settings.topMargin }}px;
         {% else %}
-            margin: 5px;
+            margin-top: 5px;
+        {% endif %}
+        {% if plugin_settings.bottomMargin %}
+            margin-bottom: {{ plugin_settings.bottomMargin }}px;
+        {% else %}
+            margin-bottom: 5px;
+        {% endif %}
+        {% if plugin_settings.leftMargin %}
+            margin-left: {{ plugin_settings.leftMargin }}px;
+        {% else %}
+            margin-left: 5px;
+        {% endif %}
+        {% if plugin_settings.rightMargin %}
+            margin-right: {{ plugin_settings.rightMargin }}px;
+        {% else %}
+            margin-right: 5px;
         {% endif %}
         --container-height: {{ height }}px;
         --container-width: {{ width }}px;

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -284,6 +284,8 @@
                                 <input type="number" class="form-input" id="topMargin" name="topMargin" min="0" max="40" step="5">px
                                 <label for="margin" class="form-label">Bottom Margin:</label>
                                 <input type="number" class="form-input" id="bottomMargin" name="bottomMargin" min="0" max="40" step="5">px
+                            </div>
+                            <div class="form-group nowrap">
                                 <label for="margin" class="form-label">Left Margin:</label>
                                 <input type="number" class="form-input" id="leftMargin" name="leftMargin" min="0" max="40" step="5">px
                                 <label for="margin" class="form-label">Right Margin:</label>

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -173,7 +173,10 @@
             }
             if (loadPluginSettings) {
                 if (pluginSettings.margin) {
-                    document.getElementById('margin').value = pluginSettings.margin;
+                    document.getElementById('topMargin').value = pluginSettings.topMargin;
+                    document.getElementById('bottomMargin').value = pluginSettings.bottomMargin;
+                    document.getElementById('leftMargin').value = pluginSettings.leftMargin;
+                    document.getElementById('rightMargin').value = pluginSettings.rightMargin;
                 }
                 // Populate background options (color or image)
                 if (pluginSettings.backgroundOption) {
@@ -277,8 +280,14 @@
                             </div>
 
                             <div class="form-group nowrap">
-                                <label for="margin" class="form-label">Margin:</label>
-                                <input type="number" class="form-input" id="margin" name="margin" min="0" max="40" step="5">px
+                                <label for="margin" class="form-label">Top Margin:</label>
+                                <input type="number" class="form-input" id="topMargin" name="topMargin" min="0" max="40" step="5">px
+                                <label for="margin" class="form-label">Bottom Margin:</label>
+                                <input type="number" class="form-input" id="bottomMargin" name="bottomMargin" min="0" max="40" step="5">px
+                                <label for="margin" class="form-label">Left Margin:</label>
+                                <input type="number" class="form-input" id="leftMargin" name="leftMargin" min="0" max="40" step="5">px
+                                <label for="margin" class="form-label">Right Margin:</label>
+                                <input type="number" class="form-input" id="bottomMargin" name="bottomMargin" min="0" max="40" step="5">px
                             </div>
                         </div>    
                         

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -287,7 +287,7 @@
                                 <label for="margin" class="form-label">Left Margin:</label>
                                 <input type="number" class="form-input" id="leftMargin" name="leftMargin" min="0" max="40" step="5">px
                                 <label for="margin" class="form-label">Right Margin:</label>
-                                <input type="number" class="form-input" id="bottomMargin" name="bottomMargin" min="0" max="40" step="5">px
+                                <input type="number" class="form-input" id="rightMargin" name="rightMargin" min="0" max="40" step="5">px
                             </div>
                         </div>    
                         


### PR DESCRIPTION
Break apart the margin setting to support configuring the margin on each individual side. This was mainly so I wouldn't have to trim or cut the frame border that came with the Ikea frame on the left and right side.

![image](https://github.com/user-attachments/assets/da53503a-5a47-4d91-98e3-6499b5251fdd)

Sample of 5px top and bottom, 40px left and right:
![image](https://github.com/user-attachments/assets/42ee7810-c41d-4350-8916-9dbaaacb5f37)
