### PR TITLE
Add MakerWorld reference for Inky Impression 7.3" (2025 Edition) 3D printable frame

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -7,4 +7,5 @@ A collection of 3D models, custom builds, and frames contributed by the communit
 |---------|-------------|------------|---------|
 | 7.3" Inky Impression | 3D Printable bezel for IKEA Rodalm Frame | [3D model](https://makerworld.com/en/models/1221196-ikea-rodlam-inky-impression-7-mount) | [MatthewAlner](https://github.com/MatthewAlner) |
 | 7.3" Inky Impression | 3D Printable bezel for IKEA Rodalm Frame | [3D model](https://makerworld.com/en/models/1242875-inky-impression-bezel-for-ikea-rodalm#profileId-1263722) | [scotthsieh0503](https://github.com/scotthsieh0503) |
+| 7.3" Inky Impression (2025 Edition) | 3D Printable frame with stand | [3D model](https://makerworld.com/en/models/1482862-inky-impression-2025-edition-7-3-frame#profileId-1548643) | [JeremyCottontail](https://github.com/JeremyCottontail) |
 | 5.7" Inky Impression | Lego Stand | [Instructions](https://github.com/pikesley/impression-clock?tab=readme-ov-file#making-the-stand) | [pikesley](https://github.com/pikesley) |


### PR DESCRIPTION
### Description
Added a reference to a 3D printable frame available on MakerWorld specifically designed for the newer Inky Impression 7.3" (2025 Edition) display.

### Changes
- Updated docs/community.md to include MakerWorld link for the 2025 Edition frame
- Added reference alongside existing frame options for the Inky Impression 7.3"

### Context
The newer 2025 Edition of the Inky Impression 7.3" display has different dimensions/mounting requirements compared to the original version, requiring a specifically designed frame. This addition provides users with an accessible 3D printing option for the updated hardware.