### PR TITLE
Modify install.sh and update.sh to suppress pip warnings

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -103,7 +103,8 @@ install_debian_dependencies() {
 create_venv(){
   echo "Creating python virtual environment. "
   python3 -m venv "$VENV_PATH"
-  $VENV_PATH/bin/python -m pip install -r $PIP_REQUIREMENTS_FILE > /dev/null &
+  $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null &
+  $VENV_PATH/bin/python -m pip install -r $PIP_REQUIREMENTS_FILE -qq > /dev/null &
   show_loader "\tInstalling python dependencies. "
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -103,7 +103,7 @@ install_debian_dependencies() {
 create_venv(){
   echo "Creating python virtual environment. "
   python3 -m venv "$VENV_PATH"
-  $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null &
+  $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null
   $VENV_PATH/bin/python -m pip install -r $PIP_REQUIREMENTS_FILE -qq > /dev/null &
   show_loader "\tInstalling python dependencies. "
 }

--- a/install/update.sh
+++ b/install/update.sh
@@ -55,7 +55,7 @@ source "$VENV_PATH/bin/activate"
 
 # Upgrade pip
 echo "Upgrading pip..."
-$VENV_PATH/bin/python -m pip install --upgrade pip setuptools > /dev/null && echo_success "Pip upgraded successfully."
+$VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null && echo_success "Pip upgraded successfully."
 
 # Install or update Python dependencies
 if [ -f "$PIP_REQUIREMENTS_FILE" ]; then

--- a/install/update.sh
+++ b/install/update.sh
@@ -55,12 +55,12 @@ source "$VENV_PATH/bin/activate"
 
 # Upgrade pip
 echo "Upgrading pip..."
-$VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null && echo_success "Pip upgraded successfully."
+$VENV_PATH/bin/python -m pip install --upgrade pip setuptools > /dev/null && echo_success "Pip upgraded successfully."
 
 # Install or update Python dependencies
 if [ -f "$PIP_REQUIREMENTS_FILE" ]; then
   echo "Updating Python dependencies..."
-  $VENV_PATH/bin/python -m pip install --upgrade -r "$PIP_REQUIREMENTS_FILE" > /dev/null && echo_success "Dependencies updated successfully."
+  $VENV_PATH/bin/python -m pip install --upgrade -r "$PIP_REQUIREMENTS_FILE" -qq > /dev/null && echo_success "Dependencies updated successfully."
 else
   echo_error "ERROR: Requirements file $PIP_REQUIREMENTS_FILE not found!"
   exit 1


### PR DESCRIPTION
1. Add a line in `install.sh` to install/upgrade `pip`, `setuptools` and `wheel` before installing the required `pip` modules.
2. Added `-qq` to `install.sh` and `update.sh` to suppress `pip` warnings printed to stderr.

I've tested these changes using a fresh Raspberry Pi OS 64-bit Lite install on a Raspberry Pi Zero 2 and all seems well.
