### PR TITLE
Fixed a minor mistype in the AI Image Settings file that prevented the Quality setting from being set correctly.

### DIFF
--- a/src/plugins/ai_image/settings.html
+++ b/src/plugins/ai_image/settings.html
@@ -56,7 +56,7 @@
             document.getElementById('randomizePrompt').checked = pluginSettings.randomizePrompt || false;
 
             // Populate text model
-            document.getElementById('textModel').value = pluginSettings.textModel;
+            document.getElementById('imageModel').value = pluginSettings.imageModel;
 
             // Populate quality
             document.getElementById('quality').value = pluginSettings.quality;


### PR DESCRIPTION
The AI Image plugin playlist settings page was not correctly setting the "Image Model" and Quality Setting fields from the plugin settings.

I found a small mistype in the `./InkyPi/src/plugins/ai_image/settings.html` file which is probably due to a cut'n'paste error.

Correcting this seems to have fixed the issue for me.

