### PR TITLE
Improved mobile rendering of the Playlist page

### DIFF
--- a/src/static/styles/main.css
+++ b/src/static/styles/main.css
@@ -591,6 +591,7 @@ body {
 /* Plugin Item */
 .plugin-item {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     padding: 10px 25px 10px 40px;
     border-top: 2px solid #e0e0e0;
@@ -600,6 +601,13 @@ body {
 .plugin-info {
     display: flex;
     align-items: center;
+    gap: 8px;
+    flex-grow: 1;
+}
+
+.plugin-actions {
+    display: flex;
+    justify-content: flex-end;
     gap: 8px;
     flex-grow: 1;
 }

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -251,23 +251,24 @@
                                 <div id="loadingIndicator" class="loading-indicator small left-align"></div>
 
                             </div>
+                            <div class="plugin-actions">
+                                {% if plugin_instance.latest_refresh_time %}
+                                    {% set refresh_time = plugin_instance.latest_refresh_time | format_relative_time %}
+                                    <span class="latest-refresh" title="{{plugin_instance.latest_refresh_time}}">
+                                        Refreshed {{ refresh_time }}
+                                    </span>
+                                {% endif %}
 
-                            {% if plugin_instance.latest_refresh_time %}
-                                {% set refresh_time = plugin_instance.latest_refresh_time | format_relative_time %}
-                                <span class="latest-refresh" title="{{plugin_instance.latest_refresh_time}}">
-                                    Refreshed {{ refresh_time }}
-                                </span>
-                            {% endif %}
-
-                            <a href="{{ url_for('plugin.plugin_page', plugin_id=plugin_instance.plugin_id) }}?instance={{ plugin_instance.name }}" class="edit-button">
-                                <img src="{{ url_for('static', filename='icons/edit.png') }}" alt="edit plugin" class="action-icon">
-                            </a>
-                            <button class="edit-button" title="Display Now" onclick="displayPluginInstance('{{ playlist.name }}', '{{ plugin_instance.plugin_id }}','{{ plugin_instance.name }}')">
-                                <img src="{{ url_for('static', filename='icons/display.png') }}" alt="display now" class="action-icon">
-                            </button>
-                            <button class="delete-button" title="Delete Plugin Instance" onclick="deletePluginInstance('{{ playlist.name }}', '{{ plugin_instance.plugin_id }}','{{ plugin_instance.name }}')">
-                                <img src="{{ url_for('static', filename='icons/remove.png') }}" alt="delete plugin" class="action-icon">
-                            </button>
+                                <a href="{{ url_for('plugin.plugin_page', plugin_id=plugin_instance.plugin_id) }}?instance={{ plugin_instance.name }}" class="edit-button">
+                                    <img src="{{ url_for('static', filename='icons/edit.png') }}" alt="edit plugin" class="action-icon">
+                                </a>
+                                <button class="edit-button" title="Display Now" onclick="displayPluginInstance('{{ playlist.name }}', '{{ plugin_instance.plugin_id }}','{{ plugin_instance.name }}')">
+                                    <img src="{{ url_for('static', filename='icons/display.png') }}" alt="display now" class="action-icon">
+                                </button>
+                                <button class="delete-button" title="Delete Plugin Instance" onclick="deletePluginInstance('{{ playlist.name }}', '{{ plugin_instance.plugin_id }}','{{ plugin_instance.name }}')">
+                                    <img src="{{ url_for('static', filename='icons/remove.png') }}" alt="delete plugin" class="action-icon">
+                                </button>
+                            </div>
                         </div>
                         {% endfor %}
                     </div>


### PR DESCRIPTION
Added an additional DIV and CSS style to group the action buttons together so they move to a new line when the Playlist item is too long.

Example of how this will look on a narrow device after the change:

![Screenshot_20250623-163623](https://github.com/user-attachments/assets/d7275a33-ac51-4520-8e87-b815be0bbf34)

'Normal' width rendering should not be affected, and should look the same.