### PR TITLE
Improve orientation and inversion process so the 'top' is displayed in all cases.

### DIFF
--- a/src/display/display_manager.py
+++ b/src/display/display_manager.py
@@ -63,8 +63,9 @@ class DisplayManager:
         image.save(self.device_config.current_image_file)
 
         # Resize and adjust orientation
-        image = change_orientation(image, self.device_config.get_config("orientation"), self.device_config.get_config("inverted_image"))
+        image = change_orientation(image, self.device_config.get_config("orientation"))
         image = resize_image(image, self.device_config.get_resolution(), image_settings)
+        if self.device_config.get_config("inverted_image"): image = image.rotate(180)
         image = apply_image_enhancement(image, self.device_config.get_config("image_settings"))
 
         # Pass to the concrete instance to render to the device.


### PR DESCRIPTION
PR to address the issue raised in: https://github.com/fatihak/InkyPi/issues/176

When inverting the image the 'bottom' of the image is displayed, as opposed to the usual 'top' of the image.

This change addresses this by separating the orientation step from the inversion step. 

This allows the resize to happen before the inversion and results in the 'top' of an image being constantly displayed, in both horizontal and vertical modes.

