### PR TITLE
Add a Download Logs feature to Settings Page

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -10,3 +10,4 @@ openai==1.58.1
 numpy==2.2.1
 icalendar==6.3.1
 recurring-ical-events==3.7.0
+cysystemd==2.0.1

--- a/src/blueprints/settings.py
+++ b/src/blueprints/settings.py
@@ -121,5 +121,6 @@ def download_logs():
         )
 
     except Exception as e:
+        logger.error(f"Error reading logs: {e}")
         return Response(f"Error reading logs: {e}", status=500, mimetype="text/plain")
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -99,7 +99,7 @@
                     <h1 class="app-title">Settings</h1>
                 </div>
                 <div>
-                    <a class="header-button" style="text-decoration: none; background-color: #2c66b1; color: #fff;" href="{{ url_for('settings.download_logs', hours=2) }}" download>Download Logs</a>
+                    <a class="header-button" style="text-decoration: none; background-color: #2c66b1; color: #fff;" href="{{ url_for('settings.download_logs', hours=24) }}" download>Download Logs</a>
                     <button class="header-button" style="background-color: #FFD600; color: #333;" onclick="handleShutdown(true)">Reboot</button>
                     <button class="header-button" style="background-color: #E53935; color: #fff;" onclick="handleShutdown(false)">Shutdown</button>
                 </div>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -99,8 +99,9 @@
                     <h1 class="app-title">Settings</h1>
                 </div>
                 <div>
-                    <button class="header-button" onclick="handleShutdown(true)">Reboot</button>
-                    <button class="header-button" onclick="handleShutdown(false)">Shutdown</button>
+                    <a class="header-button" style="text-decoration: none; background-color: #2c66b1; color: #fff;" href="{{ url_for('settings.download_logs', hours=2) }}" download>Download Logs</a>
+                    <button class="header-button" style="background-color: #FFD600; color: #333;" onclick="handleShutdown(true)">Reboot</button>
+                    <button class="header-button" style="background-color: #E53935; color: #fff;" onclick="handleShutdown(false)">Shutdown</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Add a "Download Logs" button to the Settings page.

Logs are read via a python systemd module ('cysystemd') so should support reading from volatile (default) or persistent (survives reboots) storage. The download button currently downloads the last 24 hours worth of log entries, but the supporting function in 'settings.py' accepts a parameter, so this can be changed, or support a feature to allow user selectable range being added later.

Also changed the colours of the 'Reboot' and 'Shutdown' to indicate their relative consequence levels.

![image](https://github.com/user-attachments/assets/f1f97bd2-457e-44f6-92b6-c1cfa3b1c594)

Comments and suggestions are welcome.
