### PR TITLE
Add emoji support for Calendar Event Titles

### DIFF
--- a/install/debian-requirements.txt
+++ b/install/debian-requirements.txt
@@ -7,3 +7,4 @@ libopenblas-dev
 libopenjp2-7
 chromium-headless-shell
 libfreetype6-dev
+fonts-noto-color-emoji


### PR DESCRIPTION
Added fonts-noto-color-emoji to debian-requirements.txt for emoji support, primarily on the calendar plugin when calendar event titles include emoji
![current_image](https://github.com/user-attachments/assets/cb473402-4198-4889-91a5-934350a888c6)

