### PR TITLE
Adding a randamization option to the Photo Upload Plugin

### DIFF
--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -1,4 +1,4 @@
-from plugins.base_plugin.base_plugin import BasePlugin
+from ...plugins.base_plugin.base_plugin import BasePlugin
 from PIL import Image, ImageOps, ImageColor
 from io import BytesIO
 import logging
@@ -6,15 +6,9 @@ import random
 
 logger = logging.getLogger(__name__)
 
+
 class ImageUpload(BasePlugin):
-    def generate_image(self, settings, device_config):
-        img_index = settings.get("image_index", 0)
-        image_locations = settings.get("imageFiles[]")
-
-        if img_index >= len(image_locations):
-            # reset if image_locations changed
-            img_index = 0
-
+    def open_image(self, img_index: int, image_locations: list) -> Image:
         if not image_locations:
             raise RuntimeError("No images provided.")
         # Open the image using Pillow
@@ -23,12 +17,29 @@ class ImageUpload(BasePlugin):
         except Exception as e:
             logger.error(f"Failed to read image file: {str(e)}")
             raise RuntimeError("Failed to read image file.")
+        return image
+        
 
+    def generate_image(self, settings, device_config) -> Image:
+        
+        # Get the current index from the device json
+        img_index = settings.get("image_index", 0)
+        image_locations = settings.get("imageFiles[]")
+
+        if img_index >= len(image_locations):
+            # Prevent Index out of range issues when file list has changed
+            img_index = 0
 
         if settings.get('randomize') == "true":
-            settings['image_index'] = random.randint(0, len(image_locations))
+            img_index = random.randint(0, len(image_locations))
+            image = self.open_image(img_index, image_locations)
         else:
-            settings['image_index'] = (img_index + 1) % len(image_locations)
+            image = self.open_image(img_index, image_locations)
+            img_index = (img_index + 1) % len(image_locations)
+
+        # Write the new index back ot the device json
+        settings['image_index'] = img_index
+
         ###
         if settings.get('padImage') == "true":
             dimensions = device_config.get_resolution()

--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -31,7 +31,7 @@ class ImageUpload(BasePlugin):
             img_index = 0
 
         if settings.get('randomize') == "true":
-            img_index = random.randint(0, len(image_locations))
+            img_index = random.randrange(0, len(image_locations))
             image = self.open_image(img_index, image_locations)
         else:
             image = self.open_image(img_index, image_locations)

--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -2,6 +2,7 @@ from plugins.base_plugin.base_plugin import BasePlugin
 from PIL import Image, ImageOps, ImageColor
 from io import BytesIO
 import logging
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,11 @@ class ImageUpload(BasePlugin):
             logger.error(f"Failed to read image file: {str(e)}")
             raise RuntimeError("Failed to read image file.")
 
-        settings['image_index'] = (img_index + 1) % len(image_locations)
+
+        if settings.get('randomize') == "true":
+            settings['image_index'] = random.randint(0, len(image_locations))
+        else:
+            settings['image_index'] = (img_index + 1) % len(image_locations)
         ###
         if settings.get('padImage') == "true":
             dimensions = device_config.get_resolution()

--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -1,4 +1,4 @@
-from ...plugins.base_plugin.base_plugin import BasePlugin
+from plugins.base_plugin.base_plugin import BasePlugin
 from PIL import Image, ImageOps, ImageColor
 from io import BytesIO
 import logging

--- a/src/plugins/image_upload/settings.html
+++ b/src/plugins/image_upload/settings.html
@@ -5,7 +5,7 @@
             onclick="this.value = this.checked ? 'true' : 'false'">
         <label for="padImage" class="toggle-label"></label>
     </div>
-    <label for="randomize" class="form-label">Randomize:</label>
+    <label for="randomize" class="form-label">Randomize Order:</label>
     <div class="toggle-container">
         <input type="checkbox" id="randomize" name="randomize" class="toggle-checkbox" value="false"
             onclick="this.value = this.checked ? 'true' : 'false'">
@@ -18,7 +18,9 @@
 <div class="form-group">
     <label for="imageUpload" class="form-input file-upload-label">Choose Image</label>
     <input type="file" clear-on-submit id="imageUpload" name="imageFiles[]" accept="image/*" multiple class="file-upload-input" onchange="addFiles()">
+    <button onclick="sortFiles()">Sort</button>
 </div>
+
 
 <!-- Display uploaded & existing file names -->
 <div class="form-group">
@@ -62,6 +64,12 @@
         fileInput.value = "";
     }
 
+    function sortFiles() {
+        console.log("here")
+        console.log(pluginSettings["imageFiles[]"].sort())
+        pluginSettings["imageFiles[]"] = pluginSettings["imageFiles[]"].sort()
+    }
+
     function removeAddedFile(fileName) {
         // Remove the file from uploadedFiles
         uploadedFiles["imageFiles[]"] = uploadedFiles["imageFiles[]"].filter(f => f.name !== fileName);
@@ -70,6 +78,11 @@
         document.getElementById(`added-${fileName}`).remove();
     }
 
+    function removeAllFiles() {
+        console.log("here")
+        console.log(pluginSettings["imageFiles[]"].sort())
+        pluginSettings["imageFiles[]"] = pluginSettings["imageFiles[]"].sort()
+    }
     function removeExistingFile(fileName) {
         document.getElementById(`existing-${fileName}`).remove(); // Remove from display
         document.getElementById(`hidden-${fileName}`).remove(); // Remove hidden input

--- a/src/plugins/image_upload/settings.html
+++ b/src/plugins/image_upload/settings.html
@@ -18,9 +18,7 @@
 <div class="form-group">
     <label for="imageUpload" class="form-input file-upload-label">Choose Image</label>
     <input type="file" clear-on-submit id="imageUpload" name="imageFiles[]" accept="image/*" multiple class="file-upload-input" onchange="addFiles()">
-    <button onclick="sortFiles()">Sort</button>
 </div>
-
 
 <!-- Display uploaded & existing file names -->
 <div class="form-group">
@@ -64,12 +62,6 @@
         fileInput.value = "";
     }
 
-    function sortFiles() {
-        console.log("here")
-        console.log(pluginSettings["imageFiles[]"].sort())
-        pluginSettings["imageFiles[]"] = pluginSettings["imageFiles[]"].sort()
-    }
-
     function removeAddedFile(fileName) {
         // Remove the file from uploadedFiles
         uploadedFiles["imageFiles[]"] = uploadedFiles["imageFiles[]"].filter(f => f.name !== fileName);
@@ -78,11 +70,6 @@
         document.getElementById(`added-${fileName}`).remove();
     }
 
-    function removeAllFiles() {
-        console.log("here")
-        console.log(pluginSettings["imageFiles[]"].sort())
-        pluginSettings["imageFiles[]"] = pluginSettings["imageFiles[]"].sort()
-    }
     function removeExistingFile(fileName) {
         document.getElementById(`existing-${fileName}`).remove(); // Remove from display
         document.getElementById(`hidden-${fileName}`).remove(); // Remove hidden input

--- a/src/plugins/image_upload/settings.html
+++ b/src/plugins/image_upload/settings.html
@@ -5,6 +5,12 @@
             onclick="this.value = this.checked ? 'true' : 'false'">
         <label for="padImage" class="toggle-label"></label>
     </div>
+    <label for="randomize" class="form-label">Randomize:</label>
+    <div class="toggle-container">
+        <input type="checkbox" id="randomize" name="randomize" class="toggle-checkbox" value="false"
+            onclick="this.value = this.checked ? 'true' : 'false'">
+        <label for="randomize" class="toggle-label"></label>
+    </div>
     <label for="backgroundColor" class="form-label">Background Color:</label>
     <input type="color" id="backgroundColor" name="backgroundColor" value="#ffffff"/>
 </div>
@@ -75,6 +81,7 @@
         const hiddenFileInputs = document.getElementById("hiddenFileInputs");
         if (loadPluginSettings) {
             document.getElementById('padImage').checked = pluginSettings.padImage;
+            document.getElementById('randomize').checked = pluginSettings.randomize;
             document.getElementById('backgroundColor').value = pluginSettings.backgroundColor;
 
             const existingFiles = pluginSettings['imageFiles[]'] || []


### PR DESCRIPTION
Problem:
I have a playlist with a big photo library and I wanted a way to randomly cycle through them. Existing functionality would iterate through them in upload order but I wanted a way to randomize that display order.
When Randomization is set the initial picture displayed is also randomized

Solution:
Add a new Randomize toggle in the HTML and call it in the image upload plugin.

Example:
<img width="712" height="224" alt="image" src="https://github.com/user-attachments/assets/66b1803a-1ad9-4c99-83b9-3584220b65b7" />
