### PR TITLE
add webp as a supported image format

### DIFF
--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -127,7 +127,7 @@ def parse_form(request_form):
     return request_dict
 
 def handle_request_files(request_files, form_data={}):
-    allowed_file_extensions = {'pdf', 'png', 'jpg', 'jpeg', 'gif'}
+    allowed_file_extensions = {'pdf', 'png', 'jpg', 'jpeg', 'gif', 'webp'}
     file_location_map = {}
     # handle existing file locations being provided as part of the form data
     for key in set(request_files.keys()):


### PR DESCRIPTION
Description: 
Pillow added support for webp in version 2.1.0, this requires libwebp-dev but this is a dependency of libtiff-dev 
which is already in the debian-requirements.txt file. Current Pillow version requirement for the project is currently pillow==11.0.0

https://packages.debian.org/sid/libtiff-dev 
https://pypi.org/project/pillow/2.1.0/

Tested locally with various web after making this change.

Problem:
webp is excluded as a valid file extension even though supported and working. 

Solution:
Add .webp to the list of supported image extensions.