### PR TITLE
Add feature to the Weather Plugin to allow choosing local or location TimeZone for OpenWeatherMap API

### DIFF
--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -75,6 +75,15 @@
         </select>
         days
     </div>
+
+    <div class="form-group">
+        <label for="weatherTimeZone" class="form-label">Time Zone:</label>
+        <select id="weatherTimeZone" name="weatherTimeZone" class="form-input">
+            <option value="locationTimeZone">Use Location Time Zone</option>
+            <option value="localTimeZone">Use Local Time Zone</option>
+        </select>
+    </div>
+
 </div>
 
 <div id="mapModal" class="modal">
@@ -94,12 +103,17 @@
         const titleLocationLabel = document.querySelector('label[for="title-location"]');
         const titleCustomRadio = document.getElementById('title-custom');
         const customTitleInput = document.getElementById('customTitle');
+        const titleTimeZone = document.getElementById('weatherTimeZone');
+        const titleTimeZoneLabel = document.querySelector('label[for="weatherTimeZone"]');
 
         if (provider === 'OpenMeteo') {
             // Hide or disable "Location" radio option
             titleLocationRadio.style.display = 'none';
             titleLocationLabel.style.display = 'none';
             titleLocationRadio.disabled = true;
+            titleTimeZone.style.display = 'none';
+            titleTimeZoneLabel.style.display = 'none';
+            titleTimeZone.disabled = true;
 
             // Select and enable "Custom"
             titleCustomRadio.checked = true;
@@ -113,6 +127,10 @@
 
             titleCustomRadio.disabled = false;
             customTitleInput.disabled = false;
+
+            titleTimeZone.style.display = '';
+            titleTimeZoneLabel.style.display = '';
+            titleTimeZone.disabled = false;
         }
     }
 
@@ -175,6 +193,8 @@
 
             document.getElementById('forecastDays').value = pluginSettings.forecastDays;
             document.getElementById('moonPhase').checked = pluginSettings.moonPhase;
+
+            document.getElementById('weatherTimeZone').value = pluginSettings.weatherTimeZone;
             
             selectedTitle = pluginSettings.titleSelection || 'location';
             weatherProvider = pluginSettings.weatherProvider || 'OpenWeatherMap';
@@ -191,9 +211,9 @@
             document.getElementById('displayGraph').value = "true";
             document.getElementById('displayForecast').checked = true;
             document.getElementById('displayForecast').value = "true";
-
-            document.getElementById('forecastDays').value = 7
+            document.getElementById('forecastDays').value = 7;
             document.getElementById('moonPhase').checked = false;
+            document.getElementById('weatherTimeZone').value = "locationTimeZone";
         }
 
         document.getElementById('weatherProvider').value = weatherProvider;


### PR DESCRIPTION
Currently the Weather Plugin, when using OpenWeatherMap, always show times in the local timezone (i.e. whatever has been set as the timezone in the settings page).

The OpenWeatherMap API returns the times in UTC, and the timezone of the location requested, therefore we can choose the use the local timezone, or the location timezone when converting the times.

The Openmeteo API returns the times in the location timezone (and specifies which timezone that is), so I'm not sure if this is working as expected at the moment; therefore I have not made this feature available for this API yet.