### PR TITLE
Add moonPhase value assignment to fix Moon Phase setting not working when saving plugin settings

### DIFF
--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -174,7 +174,9 @@
             document.getElementById('displayForecast').value = pluginSettings.displayForecast;
 
             document.getElementById('forecastDays').value = pluginSettings.forecastDays;
+
             document.getElementById('moonPhase').checked = pluginSettings.moonPhase;
+            document.getElementById('moonPhase').value = pluginSettings.moonPhase;
             
             selectedTitle = pluginSettings.titleSelection || 'location';
             weatherProvider = pluginSettings.weatherProvider || 'OpenWeatherMap';


### PR DESCRIPTION
Small PR to fix the Moon Phase setting being set incorrectly when saving plugin instance settings.

Should fix the issue as reported here: https://github.com/fatihak/InkyPi/issues/245