### PR TITLE
Pin required Chromium Packages to "138.0.7204.183-1~deb12u1" as a workaround for issue #257

### DIFF
--- a/install/debian-requirements.txt
+++ b/install/debian-requirements.txt
@@ -5,7 +5,8 @@ python3-pip
 avahi-daemon
 libopenblas-dev
 libopenjp2-7
-chromium-headless-shell
+chromium-common=138.0.7204.183-1~deb12u1
+chromium-headless-shell=138.0.7204.183-1~deb12u1
 libfreetype6-dev
 fonts-noto-color-emoji
 zram-tools


### PR DESCRIPTION
An issue with version "139.0.7258.66-1~deb12u1+rpt1" of Chromium-Common and Chromium-Headless-Shell has been identified; a workaround of downgrading to the previous release has been confirmed.

The issue is being tracked here: https://github.com/fatihak/InkyPi/issues/257

This PR adds explicit versions in the `install/debian-requirements.txt` file which should ensure that only that version is installed during an install. If newer packages are already installed (i.e. during an update) they should be downgraded to the known working version.
