### PR TITLE
Fix system dependencies install on pristine OS

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -181,6 +181,9 @@ echo_blue() {
 
 install_debian_dependencies() {
   if [ -f "$APT_REQUIREMENTS_FILE" ]; then
+    sudo apt-get update > /dev/null &
+    show_loader "Fetch available system dependencies updates. " 
+
     xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null &
     show_loader "Installing system dependencies. "
   else


### PR DESCRIPTION
On a pristine OS install (in my case: Raspberry PI OS Lite)  there might never have been run `apt-get update`.
But without a previous run, the following `apt-get install $debian_deps_here$` will _most likely_ fail.

This fixes it by running apt-get update before apt-get install.