### PR TITLE
Modify 'chromium-headless-shell' parameters to work with version 139 without "Bus error"

### DIFF
--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -113,17 +113,18 @@ def take_screenshot(target, dimensions, timeout_ms=None):
             "--headless",
             f"--screenshot={img_file_path}",
             f"--window-size={dimensions[0]},{dimensions[1]}",
-            "--no-sandbox",
-            "--disable-gpu",
-            "--disable-software-rasterizer",
-            "--disable-background-networking",
             "--disable-dev-shm-usage",
+            "--disable-gpu",
+            "--use-gl=swiftshader",
             "--hide-scrollbars",
-            "--single-process",
+            "--in-process-gpu",
+            "--js-flags=--jitless",
+            "--disable-zero-copy",
+            "--disable-gpu-memory-buffer-compositor-resources",
             "--disable-extensions",
             "--disable-plugins",
             "--mute-audio",
-            "--js-flags=--max_old_space_size=128"
+            "--no-sandbox"
         ]
         if timeout_ms:
             command.append(f"--timeout={timeout_ms}")
@@ -144,5 +145,5 @@ def take_screenshot(target, dimensions, timeout_ms=None):
 
     except Exception as e:
         logger.error(f"Failed to take screenshot: {str(e)}")
-    
+
     return image


### PR DESCRIPTION
After spending more time with ChatGPT than I would like to admit, I think I have a set of parameters that allows 'chromium-headless-shell' to work reliably on version '1:139.0.7258.66-1~deb12u1+rpt1'.

I've tested in '1:139.0.7258.66-1~deb12u1+rpt1', and the previous '138.0.7204.183-1~deb12u1', and it seems to be working reliably, but more testing would be prudent.

This should close issue: https://github.com/fatihak/InkyPi/issues/257, but will also need the pinning of version '138.0.7204.183-1~deb12u1' to be removed.

Summary of the parameters:
- `--headless` – Run without a visible UI (headless mode).
- `--screenshot=screenshot.png` – Save a screenshot to `screenshot.png`.
- `--window-size=800,480` – Set virtual window size to 800×480.
- `--disable-dev-shm-usage` – Avoid `/dev/shm`, use disk for shared memory.
- `--disable-gpu` – Disable hardware GPU acceleration.
- `--use-gl=swiftshader` – Use SwiftShader (software renderer).
- `--hide-scrollbars` – Hide scrollbars in output.
- `--in-process-gpu` – Run GPU in the same process (avoid crashes).
- `--js-flags=--jitless` – Disable JIT, run JS in interpreter-only mode.
- `--disable-zero-copy` – Don’t use zero-copy GPU memory sharing.
- `--disable-gpu-memory-buffer-compositor-resources` – Don’t use GPU memory buffers for compositor.
- `--no-sandbox` – Disable Chromium sandbox (required when running as root).

List of Chromium parameters:
https://peter.sh/experiments/chromium-command-line-switches/


