### PR TITLE
Calendar: Option to adjust number of days displayed in week view

### DIFF
--- a/src/plugins/calendar/calendar.py
+++ b/src/plugins/calendar/calendar.py
@@ -101,7 +101,7 @@ class Calendar(BasePlugin):
             if settings.get("displayPreviousDays") == "true":
                 start = current_dt - timedelta(days=current_dt.weekday())
                 start = datetime(start.year, start.month, start.day)
-            end = start + timedelta(days=7)
+            end = start + timedelta(days=int(settings.get("numDays")))
         elif view == "dayGridMonth":
             start = datetime(current_dt.year, current_dt.month, 1) - timedelta(weeks=1)
             end = datetime(current_dt.year, current_dt.month, 1) + timedelta(weeks=6)

--- a/src/plugins/calendar/render/calendar.html
+++ b/src/plugins/calendar/render/calendar.html
@@ -50,7 +50,7 @@
             weekends:  {{ (plugin_settings.displayWeekends == "true") | tojson}},
             nowIndicator: {{ (plugin_settings.displayNowIndicator == "true") | tojson}},
             fixedWeekCount: false,
-            {% if view == 'timeGrid' %}duration: {days : 7 },{% endif %}
+            {% if view == 'timeGrid' %}duration: {days : {{ plugin_settings.numDays | int }} },{% endif %}
             headerToolbar: {
                 left: '',
                 center: "{{ 'title' if plugin_settings.displayTitle == 'true' else '' }}",

--- a/src/plugins/calendar/settings.html
+++ b/src/plugins/calendar/settings.html
@@ -56,6 +56,21 @@
 </div>
 
 <div class="form-group">
+    <div class="form-group nowrap" data-visible-modes="timeGridWeek">
+        <label for="numDays" class="form-label">Number of days to display:</label>
+        <select id="numDays" name="numDays" class="form-input">
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7" selected>7</option>
+        </select>
+    </div>
+</div>
+
+<div class="form-group">
     <div class="form-group nowrap" data-visible-modes="timeGridWeek,dayGridMonth">
         <label for="weekStartDay" class="form-label">Week Start Day:</label>
         <select id="weekStartDay" name="weekStartDay" class="form-input">


### PR DESCRIPTION
Description: 
Using a 7,3" screen, displaying the "week" view of the calendar will result in narrow individual columns for each day. One possible solution is to exclude previous days and to only display the next [1-7] days. I added a small option to  choose the number of days to display via a drop-down menu. 