### PR TITLE
Fix: Rename method image_blur

### DIFF
--- a/src/plugins/image_folder/image_folder.py
+++ b/src/plugins/image_folder/image_folder.py
@@ -29,7 +29,7 @@ def grab_image(image_path, dimensions, pad_image):
         img = ImageOps.contain(img, dimensions, Image.Resampling.LANCZOS)
 
         if pad_image:
-            img = pad_image_blurry(img, dimensions)
+            img = pad_image_blur(img, dimensions)
         return img
     except Exception as e:
         logger.error(f"Error loading image from {image_path}: {e}")


### PR DESCRIPTION
The method had the wrong name.
So when selecting Fit the image to the frame on image folder options, it wasnt working