### PR TITLE
Check for OS version and only install zramswap on Bookworm

### DIFF
--- a/install/debian-requirements.txt
+++ b/install/debian-requirements.txt
@@ -8,5 +8,3 @@ libopenjp2-7
 chromium-headless-shell
 libfreetype6-dev
 fonts-noto-color-emoji
-zram-tools
-earlyoom


### PR DESCRIPTION
Raspberry Pi OS 13 (Trixie) has been released.

Trixie includes a zram based swap out of the box:

https://forums.raspberrypi.com/viewtopic.php?t=390708

The zram-tools package the InkyPi 'install.sh' installs conflicts with the pre-installed 'rpi-swap' package.

This PR modifies the 'install.sh' file by adding a OS version check and only installing/configuring zram-tools/zramswap on Raspberry Pi OS 12 (Bookworm).
