### PR TITLE
Fix multi-week fetch range in calendar.py

### DIFF
--- a/src/plugins/calendar/calendar.py
+++ b/src/plugins/calendar/calendar.py
@@ -46,6 +46,7 @@ class Calendar(BasePlugin):
 
         current_dt = datetime.now(tz)
         start, end = self.get_view_range(view, current_dt, settings)
+        logger.debug(f"Fetching events for {start} --> [{current_dt}] --> {end}")
         events = self.fetch_ics_events(calendar_urls, calendar_colors, tz, start, end)
         if not events:
             logger.warn("No events found for ics url")
@@ -106,8 +107,8 @@ class Calendar(BasePlugin):
                 start = datetime(start.year, start.month, start.day)
             end = start + timedelta(days=7)
         elif view == "dayGrid":
-            start = datetime(current_dt.year, current_dt.month, 1) - timedelta(weeks=1)
-            end = datetime(current_dt.year, current_dt.month, 1) + timedelta(weeks=int(settings.get("displayWeeks") or 4))
+            start = current_dt - timedelta(weeks=1)
+            end = current_dt + timedelta(weeks=int(settings.get("displayWeeks") or 4))
         elif view == "dayGridMonth":
             start = datetime(current_dt.year, current_dt.month, 1) - timedelta(weeks=1)
             end = datetime(current_dt.year, current_dt.month, 1) + timedelta(weeks=6)


### PR DESCRIPTION
Previously the copy-pasta'd event range in the mult-week view from the month view was pulling only the currrent month's events:

`DEBUG - plugins.calendar.calendar - Fetching events for 2025-09-24 00:00:00 --> [2025-10-26 07:45:22.314152-05:00] --> 2025-10-29 00:00:00`
![multi-week-before](https://github.com/user-attachments/assets/632b5fa0-909d-4453-85b4-5f4fe438033b)

---
Post fix is to have the multi-week range reference the month, week, AND day when calculating a range:

`DEBUG - plugins.calendar.calendar - Fetching events for 2025-10-19 08:15:07.314676-05:00 --> [2025-10-26 08:15:07.314676-05:00] --> 2025-11-23 08:15:07.314676-05:00`
![multi-week-fixed](https://github.com/user-attachments/assets/fca0e44e-cc76-43ca-994c-87eab2b39928)
