### PR TITLE
add .idea to .gitignore (PyCharm/Intellij Settings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 
 # Development artifacts
 mock_display_output/
+
+# IDE files
+.idea


### PR DESCRIPTION
Adds .idea to .gitignore so that PyCharm and Intellij aren't commit their IDE settings to repository. 