### PR TITLE
Add System Packages for Trixie Waveshare Python local build

### DIFF
--- a/install/debian-requirements.txt
+++ b/install/debian-requirements.txt
@@ -8,3 +8,5 @@ libopenjp2-7
 chromium-headless-shell
 libfreetype6-dev
 fonts-noto-color-emoji
+swig
+liblgpio-dev


### PR DESCRIPTION
Raspberry Pi OS Trixie is now the default OS offered on the Raspberry Pi Imager application.

Trixie has moved to Python 3.13 (from Bookworm's Python 3.11), which means some PyPI packages do not have binary wheels available for download. For example `lgpio` has binary packages available up to Python 3.12, but no 3.13:

https://pypi.org/project/lgpio/#files

`pip` is resorting to source code downloads and building locally, which means the system needs to have all the prerequisites installed for the compiling to succeed.

This PR adds the minimum set of packages required to support the local build of `lgpio`, allowing the `install.sh` script to succeed when installing InkyPi on Trixie with a Waveshare device.

For the small cost of installing these packages for everyone, it will reduce the chance for new users to encounter errors.

This situation can be monitored, and if the situation changes (i.e. PyPI binary packages are released for Python 3.13) these system packages can be removed from the install process, or the install process made more sophisticated. 

