### PR TITLE
Add support for including subfolders when listing image files in "Image Folder" plugin

### DIFF
--- a/src/plugins/image_folder/image_folder.py
+++ b/src/plugins/image_folder/image_folder.py
@@ -8,7 +8,7 @@ from utils.image_utils import pad_image_blur
 
 logger = logging.getLogger(__name__)
 
-def list_files_in_folder(folder_path, include_subfolders):
+def list_files_in_folder(folder_path):
     """Return a list of image file paths in the given folder, excluding hidden files."""
     image_extensions = ('.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.webp')
     image_files = []
@@ -16,8 +16,6 @@ def list_files_in_folder(folder_path, include_subfolders):
         for f in files:
             if f.lower().endswith(image_extensions) and not f.startswith('.'):
                 image_files.append(os.path.join(root, f))
-        if not include_subfolders:
-            break
 
     return image_files
 
@@ -37,10 +35,9 @@ class ImageFolder(BasePlugin):
         if device_config.get_config("orientation") == "vertical":
             dimensions = dimensions[::-1]
 
-        include_subfolders = settings.get('subfolders') == "true"            
-        logger.info(f"Grabbing a random image from: {folder_path} ({'including' if include_subfolders else 'excluding'} subfolders)")
+        logger.info(f"Grabbing a random image from: {folder_path}")
 
-        image_files = list_files_in_folder(folder_path, include_subfolders)
+        image_files = list_files_in_folder(folder_path)
         if not image_files:
             raise RuntimeError(f"No image files found in folder: {folder_path}")
 

--- a/src/plugins/image_folder/settings.html
+++ b/src/plugins/image_folder/settings.html
@@ -8,14 +8,6 @@
         <!-- Hidden input ensures 'true' is always sent when unchecked -->
         <input type="hidden" name="padImage" value="true">
     </div>
-    <div class="form-group">
-        <label for="subfolders" class="form-label">Include Subfolders:</label>
-        <div class="toggle-container">
-            <input type="checkbox" id="subfolders" name="subfolders" class="toggle-checkbox" value="false"
-                   onclick="this.value = this.checked ? 'true' : 'false'">
-            <label for="subfolders" class="toggle-label"></label>
-        </div>
-    </div>
 
     <div class="form-group">
         <label class="form-label" for="backgroundOption">Background:</label>
@@ -42,7 +34,6 @@
         if (loadPluginSettings) {
             document.getElementById('folder_path').value = pluginSettings.folder_path;
             document.getElementById('padImage').checked = pluginSettings.padImage == 'false';
-            document.getElementById('subfolders').checked = pluginSettings.subfolders || false;
             document.getElementById('backgroundColor').value = pluginSettings.backgroundColor;
 
             backgroundOption = pluginSettings.backgroundOption;


### PR DESCRIPTION
Adds a new toggle to enable scanning of subfolders for images (defaults to off to retain existing behaviour). Addresses feature request from https://github.com/fatihak/InkyPi/issues/370

Also updated log statement to indicate if subfolders are being included or excluded.

```
22:03:14 - INFO - plugins.image_folder.image_folder - Grabbing a random image from: /Users/rob/Downloads/root (excluding subfolders)
...
22:03:24 - INFO - plugins.image_folder.image_folder - Grabbing a random image from: /Users/rob/Downloads/root (including subfolders)
```

<img width="913" height="540" alt="Screenshot 2025-11-07 at 22 08 19" src="https://github.com/user-attachments/assets/862c4c83-b704-4313-bede-294faeb77d90" />
