### PR TITLE
Invert form clearing logic to retain contents unless adding to playlist

### DIFF
--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -32,7 +32,7 @@
             const formData = new FormData(form);
             let url = '{{ url_for("plugin.update_now") }}';
             let method = 'POST';
-            let clearFormOnSubmit = true;
+            let clearFormOnSubmit = false;
             
             // Add uploaded files to the form under its key
             Object.keys(uploadedFiles).forEach(key => {
@@ -51,10 +51,10 @@
                     scheduleData[key] = value;
                 }
                 formData.append("refresh_settings", JSON.stringify(scheduleData));
+                clearFormOnSubmit = true
             } else if (action == "update_instance") {
                 url = "{{ url_for('plugin.update_plugin_instance', instance_name='') }}" + pluginInstanceName,
                 method = 'PUT'
-                clearFormOnSubmit = false
             }
 
             // Send data to the server


### PR DESCRIPTION
Adjust form submission behavior: make `clearFormOnSubmit` default to false but enable it for `add_to_playlist` action.

This addresses this issue: https://github.com/fatihak/InkyPi/issues/366

I've inverted the logic so by default the form will not be cleared after submission unless the plugin is being added to a playlist. This will allow form validation issues to be corrected when there are errors without losing the form content.