### PR TITLE
Make the newspaper and wptod plugins orientation aware

### DIFF
--- a/src/plugins/newspaper/newspaper.py
+++ b/src/plugins/newspaper/newspaper.py
@@ -33,7 +33,12 @@ class Newspaper(BasePlugin):
         if image:
             # expand height if newspaper is wider than resolution
             img_width, img_height = image.size
-            desired_width, desired_height = device_config.get_resolution()
+
+            dimensions = device_config.get_resolution()
+            if device_config.get_config("orientation") == "horizontal":
+                dimensions = dimensions[::-1]
+
+            desired_width, desired_height = dimensions
 
             img_ratio = img_width / img_height
             desired_ratio = desired_width / desired_height

--- a/src/plugins/wpotd/wpotd.py
+++ b/src/plugins/wpotd/wpotd.py
@@ -57,7 +57,10 @@ class Wpotd(BasePlugin):
             logger.error("Failed to download WPOTD image.")
             raise RuntimeError("Failed to download WPOTD image.")
         if settings.get("shrinkToFitWpotd") == "true":
-            max_width, max_height = device_config.get_resolution()
+            dimensions = device_config.get_resolution()
+            if device_config.get_config("orientation") == "vertical":
+                dimensions = dimensions[::-1]
+            max_width, max_height = dimensions
             image = self._shrink_to_fit(image, max_width, max_height)
             logger.info(f"Image resized to fit device dimensions: {max_width},{max_height}")
 


### PR DESCRIPTION
When I set my device to vertical, the newspaper plugin was still rendering landscape.   Flipping Height and Width resolved it for newspaper but broke it for all other plugins.   The solution was to make newspaper orientation aware like the clock plugin.

**Update:** same done for wpotd when shrink is enabled, since it was sizing the image using vertical dimension for horizontal when device was in vertical orientation.