### PR TITLE
Add support for current_image polling

### DIFF
--- a/src/blueprints/main.py
+++ b/src/blueprints/main.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, request, jsonify, current_app, render_template
+from flask import Blueprint, request, jsonify, current_app, render_template, send_file
+import os
+from datetime import datetime
 
 main_bp = Blueprint("main", __name__)
 
@@ -6,3 +8,35 @@ main_bp = Blueprint("main", __name__)
 def main_page():
     device_config = current_app.config['DEVICE_CONFIG']
     return render_template('inky.html', config=device_config.get_config(), plugins=device_config.get_plugins())
+
+@main_bp.route('/api/current_image')
+def get_current_image():
+    """Serve current_image.png with conditional request support (If-Modified-Since)."""
+    image_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'static', 'images', 'current_image.png')
+    
+    if not os.path.exists(image_path):
+        return jsonify({"error": "Image not found"}), 404
+    
+    # Get the file's last modified time (truncate to seconds to match HTTP header precision)
+    file_mtime = int(os.path.getmtime(image_path))
+    last_modified = datetime.fromtimestamp(file_mtime)
+    
+    # Check If-Modified-Since header
+    if_modified_since = request.headers.get('If-Modified-Since')
+    if if_modified_since:
+        try:
+            # Parse the If-Modified-Since header
+            client_mtime = datetime.strptime(if_modified_since, '%a, %d %b %Y %H:%M:%S %Z')
+            client_mtime_seconds = int(client_mtime.timestamp())
+            
+            # Compare (both now in seconds, no sub-second precision)
+            if file_mtime <= client_mtime_seconds:
+                return '', 304
+        except (ValueError, AttributeError):
+            pass
+    
+    # Send the file with Last-Modified header
+    response = send_file(image_path, mimetype='image/png')
+    response.headers['Last-Modified'] = last_modified.strftime('%a, %d %b %Y %H:%M:%S GMT')
+    response.headers['Cache-Control'] = 'no-cache'
+    return response

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -4,6 +4,53 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ config.name }}</title>
+    <script>
+        let lastModified = null;
+        const refreshIntervalMs = 3 * 1000;
+
+        async function refreshImage() {
+            const img = document.querySelector('.image-container img');
+            if (!img) return;
+
+            try {
+                const headers = {};
+                if (lastModified) {
+                    headers['If-Modified-Since'] = lastModified;
+                }
+
+                const response = await fetch('{{ url_for("main.get_current_image") }}', { headers });
+                
+                if (response.status === 304) {
+                    // Image hasn't changed, no need to update
+                    return;
+                }
+
+                if (!response.ok) {
+                    console.error('Failed to fetch image:', response.status);
+                    return;
+                }
+
+                const blob = await response.blob();
+                const objectUrl = URL.createObjectURL(blob);
+                
+                // Update the image source
+                img.src = objectUrl;
+                
+                // Store the Last-Modified header for next request
+                lastModified = response.headers.get('Last-Modified');
+            } catch (error) {
+                console.error('Error refreshing image:', error);
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            // Refresh image immediately on page load
+            refreshImage();
+            
+            // Set up auto-refresh based on plugin cycle interval
+            setInterval(refreshImage, refreshIntervalMs);
+        });
+    </script>
 </head>
 <link rel= "stylesheet" type= "text/css" href= "{{ url_for('static',filename='styles/main.css') }}">
 <body>


### PR DESCRIPTION
- add support for polling via "If-Modified-Since" request header / HTTP 304 response.
- make admin UI poll every 3 seconds for current_image updates, if no update no content returned (HTTP 304).
- polling support also enables dumb frame devices (i.e. [Neoframe](https://github.com/deftdawg/neoframe)/[ESP32](https://www.good-display.com/product/574.html)) to stay updated by simply keeping track of last HTTP 200 date/time.