### PR TITLE
Add auto-setup/auto-build via jetify devbox

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetify.com/docs/devbox/ide_configuration/direnv/
+# for more details

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
+  "packages": [
+    "python@3.13",
+    "ninja@latest",
+    "chromium@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'To acivate this environment, run ''devbox shell'' (install: curl -fsSL https://get.jetify.com/devbox | bash)' >/dev/null",
+      "echo 'OR better still, install devbox w/ direnv and run ''direnv allow'' in this directory!' >/dev/null",
+      ". scripts/venv.sh",
+      "echo -e '\\n\\033[0;31m-- 🖼️ InkyPi Development Environment 🖼️ --\\033[0m'",
+      "echo -e '\\n\\033[0;34m--- 🛠️ Build / Setup Instructions 🛠️ ---\\033[0m'",
+      "echo -e '\\033[0;32mDevbox has installed all build dependencies & enabled and built your python virtal env automatically. ✅'",
+      "echo -e '\\033[0;32mPrior to first run in devloper mode be sure configure details of your InkyPi development device by editing: '",
+      "echo -e '\\033[0msrc/config/device_dev.json 📝\\033[0m'",
+      "echo -e '\\n\\033[0;34m--- ▶️ Run Instructions ▶️ ---\\033[0m'",
+      "echo -e '\\033[0;32mTo run in developer (--dev) mode:\\033[0m devbox run dev 🚀'",
+      "echo -e '\\033[0;32mThen open \\033[0mhttp://localhost:8080 🌐\\033[0;32m in your browser.\\033[0m'",
+      "echo"
+    ],
+    "scripts": {
+      "dev": [
+        "python src/inkypi.py --dev"
+      ],
+      "test": [
+        "pytest"
+      ]
+    }
+  }
+}

--- a/scripts/venv.sh
+++ b/scripts/venv.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-VENV_DIR=".venv"
+VENV_DIR="${VENV_DIR:-.venv}"
 REQUIREMENTS_FILE="install/requirements-dev.txt"
-SRC_DIR="src"
+SRC_DIR="$(realpath src)"
 
 if [ ! -d "$VENV_DIR" ]; then
     echo "Creating virtual environment in $VENV_DIR..."

--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -6,6 +6,7 @@ import logging
 import hashlib
 import tempfile
 import subprocess
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -100,15 +101,32 @@ def take_screenshot_html(html_str, dimensions, timeout_ms=None):
 
     return image
 
+def _find_chromium_binary():
+    """Find the first available Chromium-based binary in system PATH."""
+    candidates = ["chromium-headless-shell", "chromium", "chrome"]
+    for candidate in candidates:
+        path = shutil.which(candidate)
+        if path:
+            logger.debug(f"Found browser binary: {candidate} at {path}")
+            return candidate
+    return None
+
+
 def take_screenshot(target, dimensions, timeout_ms=None):
     image = None
     try:
+        # Find available browser binary
+        browser = _find_chromium_binary()
+        if not browser:
+            logger.error("No Chromium-based browser found. Install chromium, chromium-headless-shell, or chrome.")
+            return None
+
         # Create a temporary output file for the screenshot
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as img_file:
             img_file_path = img_file.name
 
         command = [
-            "chromium-headless-shell",
+            browser,
             target,
             "--headless",
             f"--screenshot={img_file_path}",
@@ -132,8 +150,7 @@ def take_screenshot(target, dimensions, timeout_ms=None):
 
         # Check if the process failed or the output file is missing
         if result.returncode != 0 or not os.path.exists(img_file_path):
-            logger.error("Failed to take screenshot:")
-            logger.error(result.stderr.decode('utf-8'))
+            logger.error(f"Failed to take screenshot (return code: {result.returncode})")
             return None
 
         # Load the image using PIL


### PR DESCRIPTION
- add devbox+direnv config to auto-install build tools,  a python virtual environment and display a dev welcome message via "devbox shell"
- update venv.sh to use bash from PATH, accept external VENV_DIR variable locations, and resolve SRC_DIR to a full path (fixing render file /tmp refering fonts via a relative path)
- update image_utils to automatically pick the first availble chromium-like browser in the path ("chromium" is used on NixOS/Fedora/MacOS/etc where "chromium-headless-shell" isn't available)

To install devbox: `curl -fsSL https://get.jetify.com/devbox | bash`
To activate devbox: `devbox shell` (from within the project directory)
