### PR TITLE
Fix service restart when oom-killer kills python process

### DIFF
--- a/install/inkypi
+++ b/install/inkypi
@@ -10,6 +10,4 @@ source "$VENV_PATH/bin/activate"
 export PROJECT_DIR="$PROGRAM_PATH"
 export SRC_DIR="$PROGRAM_PATH/src"
 
-python -u "$(realpath $PROGRAM_PATH/src/inkypi.py)"
-
-deactivate
+exec python -u "$(realpath $PROGRAM_PATH/src/inkypi.py)"


### PR DESCRIPTION
During an out-of-memory event the `inkypi` service was not restarting correctly despite being configured with `Restart=on-failure` due to the way the process is launched. A discussion on this issue https://github.com/fatihak/InkyPi/issues/426 highlighted this problem.

This small change means:

1. The Python process replaces the shell
2. `systemd` directly tracks python, not the wrapper script
3. If python receives SIGKILL (OOM kill), `systemd` sees it
4. `Restart=on-failure` now works properly

Output of an OOM kill before this change:

```
Nov 20 15:10:43 inky kernel: Out of memory: Killed process 27241 (python) total-vm:1374456kB, anon-rss:128664kB, file-rss:1600kB, shmem-rss:0kB, UID:0 pgtables:1252kB oom_score_adj:0
Nov 20 15:10:43 inky inkypi[27237]: /usr/local/bin/inkypi: line 13: 27241 Killed                  python -u "$(realpath $PROGRAM_PATH/src/inkypi.py)"
Nov 20 15:10:44 inky systemd[1]: inkypi.service: Deactivated successfully.
Nov 20 15:10:44 inky systemd[1]: inkypi.service: Consumed 7min 21.155s CPU time.
```

Output after the change:

```
Nov 20 17:40:45 inky kernel: Out of memory: Killed process 36707 (python) total-vm:770504kB, anon-rss:35644kB, file-rss:1544kB, shmem-rss:0kB, UID:0 pgtables:1032kB oom_score_adj:0
Nov 20 17:40:45 inky systemd[1]: inkypi.service: Main process exited, code=killed, status=9/KILL
Nov 20 17:40:45 inky systemd[1]: inkypi.service: Failed with result 'signal'.
Nov 20 17:40:45 inky systemd[1]: inkypi.service: Consumed 16min 49.136s CPU time.
Nov 20 17:41:45 inky systemd[1]: inkypi.service: Scheduled restart job, restart counter is at 1.
Nov 20 17:41:45 inky systemd[1]: Started inkypi.service - InkyPi App.
```

OOM events should ideally be avoided but it seems like sometimes plugins such as APOD end up pulling huge images and on a resource limited device like the Pi Zero it can be too much. This fix at least allows a graceful restart.

There is possibly some further work to do to understand why the system `oom-killer` is stepping in despite having `earlyoom` installed - I'm not sure what's going on there.