### PR TITLE
Add tab title update progress messages

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -195,8 +195,8 @@ def update_now():
 @plugin_bp.route('/update_status', methods=['GET'])
 def update_status():
     refresh_task = current_app.config['REFRESH_TASK']
-    status = refresh_task.get_status()
-    return jsonify({"status": status}), 200
+    status_info = refresh_task.get_status()
+    return jsonify(status_info), 200
 
 @plugin_bp.route('/reset_status', methods=['POST'])
 def reset_status():

--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -72,8 +72,16 @@
                 const response = await fetch('{{ url_for("plugin.update_status") }}');
                 const result = await response.json();
                 const status = result.status;
+                const refreshType = result.refresh_type;
 
-                // Update tab title and state based on status
+                // Only track manual requests (ignore scheduled/background refreshes)
+                if (refreshType !== 'manual') {
+                    // This is a scheduled refresh, not our manual request
+                    console.log(`Ignoring ${refreshType} refresh status: ${status}`);
+                    return;
+                }
+
+                // Update tab title and state based on status for manual requests
                 if (status === 'starting' || status === 'updating') {
                     document.title = status === 'starting' ? '⏳ Starting...' : '🔄 Updating...';
                     setUpdateInProgress(true);

--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -58,8 +58,16 @@
                 const response = await fetch('{{ url_for("plugin.update_status") }}');
                 const result = await response.json();
                 const status = result.status;
+                const refreshType = result.refresh_type;
 
-                // Update tab title and state based on status
+                // Only track manual requests (ignore scheduled/background refreshes)
+                if (refreshType !== 'manual') {
+                    // This is a scheduled refresh, not our manual request
+                    console.log(`Ignoring ${refreshType} refresh status: ${status}`);
+                    return;
+                }
+
+                // Update tab title and state based on status for manual requests
                 if (status === 'starting' || status === 'updating') {
                     document.title = status === 'starting' ? '⏳ Starting...' : '🔄 Updating...';
                     setUpdateInProgress(true);


### PR DESCRIPTION
**Overview**

Added real-time status tracking and browser tab title updates during e-ink display refreshes to provide user feedback during long-running display updates (30-60+ seconds).

**Problem**
- Display refresh requests were synchronous and blocking, causing the browser to appear frozen
- Users had no visibility into refresh progress when switching browser tabs

**Solution**

1. Backend Changes:
    - Made /update_now endpoint asynchronous - returns immediately instead of blocking
    - Added status tracking system with states: idle, starting, updating, complete, error
    - Implemented /update_status polling endpoint for frontend to query current status
    - Added /reset_status endpoint for manual recovery from stuck states
    - Added concurrent request protection - rejects new updates while one is in progress (HTTP 409)

2. Frontend Changes:
    - Implemented status polling (every 2 seconds) that updates browser tab title with progress
    - Tab title indicators: ⏳ Starting... → 🔄 Updating... → ✓ Complete!
    - Status persists across page navigation using sessionStorage
    - Added client-side concurrent request blocking for immediate user feedback
    - Added 3-minute safety timeout to prevent stuck states
    - Emergency resetUpdateStatus() function available in browser console (in plugin or playlist view)

**Status Flow**
- User clicks "Update Now" → Request returns immediately
- Frontend begins polling status endpoint
- Backend progresses: starting → updating → complete → idle
- Tab title updates in real-time, visible even when on other tabs
- After completion, blocks new requests for 1 second, then resets to idle