### PR TITLE
Add IP address to startup image instructions

### DIFF
--- a/src/utils/app_utils.py
+++ b/src/utils/app_utils.py
@@ -107,7 +107,7 @@ def get_font_path(font_name):
 def generate_startup_image(dimensions=(800,480)):
     bg_color = (255,255,255)
     text_color = (0,0,0)
-    width,height = dimensions
+    width, height = dimensions
 
     hostname = socket.gethostname()
     ip = get_ip_address()
@@ -120,7 +120,18 @@ def generate_startup_image(dimensions=(800,480)):
 
     text = f"To get started, visit http://{hostname}.local"
     text_font_size = width * 0.032
-    image_draw.text((width/2, height*3/4), text, anchor="mm", fill=text_color, font=get_font("Jost", text_font_size))
+
+    # Draw the instructions
+    y_text = height * 3 / 4
+    image_draw.text((width/2, y_text), text, anchor="mm", fill=text_color, font=get_font("Jost", text_font_size))
+
+    # Draw the IP on a line below
+    ip_text = f"or http://{ip}"
+    ip_text_font_size = width * 0.032
+    bbox = image_draw.textbbox((0, 0), text, font=get_font("Jost", text_font_size))
+    text_height = bbox[3] - bbox[1]
+    ip_y = y_text + text_height * 1.35
+    image_draw.text((width/2, ip_y), ip_text, anchor="mm", fill=text_color, font=get_font("Jost", ip_text_font_size))
 
     return image
 


### PR DESCRIPTION
The startup image now displays both the hostname and IP address as connection options, improving clarity for users accessing the device. The IP address is shown on a separate line below the hostname.


![20251124_224413](https://github.com/user-attachments/assets/97455e03-5e6b-4cc8-a272-025ea0f7b033)
