### PR TITLE
Improve month label rendering in contributions grid

### DIFF
--- a/src/plugins/github/render/github_contributions.html
+++ b/src/plugins/github/render/github_contributions.html
@@ -20,10 +20,17 @@
     <div class="calendar-grid">
       <!-- Month labels -->
       {% for label in month_positions %}
-        <div class="month-label"
-            style="grid-column-start: {{ label.index + 2 }}; grid-row-start: 1;">
-          {{ label.name }}
-        </div>
+        {% set idx = loop.index0 %}
+        {# Count consecutive weeks from label.index at start of this month #}
+        {% set start = label.index %}
+        {% set next_label_idx = month_positions[idx + 1].index if idx + 1 < month_positions|length else grid|length %}
+        {% set col_span = next_label_idx - start %}
+        {% if col_span >= 3 %}
+          <div class="month-label"
+              style="grid-column-start: {{ start + 2 }}; grid-row-start: 1;">
+            {{ label.name }}
+          </div>
+        {% endif %}
       {% endfor %}
       <!-- Contribution squares -->
       {% for week in grid %}


### PR DESCRIPTION
Adjusts the grid-column-start calculation for month labels in the GitHub contributions HTML to correctly align labels with the contribution grid.

### Before:
![20251208_114805](https://github.com/user-attachments/assets/046ad671-d855-4009-a379-130b8312d7d9)

### After:
![20251208_132828](https://github.com/user-attachments/assets/ecaf7239-d734-41fb-92c7-310f03462a94)

### On GitHub:
<img width="742" height="149" alt="image" src="https://github.com/user-attachments/assets/68ed42fc-d2ed-43cf-a235-25c75add3d86" />
