### PR TITLE
Apply exif image orientation when fetching images from Immich

### DIFF
--- a/src/plugins/image_album/image_album.py
+++ b/src/plugins/image_album/image_album.py
@@ -67,7 +67,9 @@ class ImmichProvider:
         logger.info(f"Downloading image {asset_id}")
         r = requests.get(f"{self.base_url}/api/assets/{asset_id}/original", headers=self.headers)
         r.raise_for_status()
-        return Image.open(BytesIO(r.content))
+        img = Image.open(BytesIO(r.content))
+        img = ImageOps.exif_transpose(img)
+        return img
 
 
 class ImageAlbum(BasePlugin):


### PR DESCRIPTION
There's a bug that is causing portrait oriented photos to sometimes be displayed as landscape and vice versa, since pillow does not apply EXIF rotation automatically. This PR consists of a one liner that applies ImageOps.exif_transpose() after loading the image, to apply the rotation stored in exif. This will make the rotation consistent with what is displayed in Immich (and most other applications)