### PR TITLE
Use miles for weather visibility when units are set to imperial

### DIFF
--- a/src/plugins/weather/weather.py
+++ b/src/plugins/weather/weather.py
@@ -32,16 +32,19 @@ def get_moon_phase_name(phase_age: float) -> str:
 UNITS = {
     "standard": {
         "temperature": "K",
-        "speed": "m/s"
+        "speed": "m/s",
+        "distance":"km"
     },
     "metric": {
         "temperature": "°C",
-        "speed": "m/s"
+        "speed": "m/s",
+        "distance":"km"
 
     },
     "imperial": {
         "temperature": "°F",
-        "speed": "mph"
+        "speed": "mph",
+        "distance":"mi"
     }
 }
 
@@ -475,12 +478,22 @@ class Weather(BasePlugin):
             "icon": self.get_plugin_dir('icons/uvi.png')
         })
 
-        visibility = weather.get('current', {}).get("visibility")/1000
-        visibility_str = f">{visibility}" if visibility >= 10 else visibility
+        visibility = weather.get('current', {}).get("visibility")
+        if units == "imperial":
+            # convert from m to mi
+            visibility /= 1609.
+            at_max_visibility = visibility >= 6.2
+        else:
+            # convert from m to km
+            visibility /= 1000.
+            at_max_visibility = visibility >= 10
+        visibility_str = f"{visibility:.1f}"
+        if at_max_visibility:
+            visibility_str = u"\u2265" + visibility_str
         data_points.append({
             "label": "Visibility",
             "measurement": visibility_str,
-            "unit": 'km',
+            "unit": UNITS[units]["distance"],
             "icon": self.get_plugin_dir('icons/visibility.png')
         })
 
@@ -594,28 +607,28 @@ class Weather(BasePlugin):
         current_visibility = "N/A"
         visibility_hourly_times = hourly_data.get('time', [])
         visibility_values = hourly_data.get('visibility', [])
+        if units == "imperial":
+            visibility_conversion = 1/5280.     # ft to mi
+            visibility_max = 6.2                # mi
+        else:
+            visibility_conversion = 0.001       # m to km
+            visibility_max = 10.                # km
         for i, time_str in enumerate(visibility_hourly_times):
             try:
                 if datetime.fromisoformat(time_str).astimezone(tz).hour == current_time.hour:
-                    visibility = visibility_values[i]
-                    if units == "imperial":
-                        current_visibility = int(round(visibility, 0))
-                        unit_label = "ft"
-                    else:
-                        current_visibility = round(visibility / 1000, 1)
-                        unit_label = "km"
+                    current_visibility = visibility_values[i]*visibility_conversion
+                    at_max_visibility = current_visibility >= visibility_max
                     break
             except ValueError:
                 logger.warning(f"Could not parse time string {time_str} for visibility.")
                 continue
-
-        visibility_str = f">{current_visibility}" if isinstance(current_visibility, (int, float)) and (
-            (units == "imperial" and current_visibility >= 32808) or 
-            (units != "imperial" and current_visibility >= 10)
-        ) else current_visibility
-
+        visibility_str = f"{current_visibility:.1f}"
+        if at_max_visibility:
+            visibility_str = u"\u2265" + visibility_str
         data_points.append({
-            "label": "Visibility", "measurement": visibility_str, "unit": unit_label,
+            "label": "Visibility", 
+            "measurement": visibility_str, 
+            "unit": UNITS[units]["distance"],
             "icon": self.get_plugin_dir('icons/visibility.png')
         })
 


### PR DESCRIPTION
Fixes #239 by switching to miles for the weather visibility when the units system is set to imperial. Changes were made for both OpenWeather (previously used km regardless of unit system) and open-meteo (previously used ft when set to imperial). I've also swapped the `>` symbol for `u"\u2265"` (`≥`) because the visibility will be greater than _or equal to_ the listed visibility.

Note: OpenWeather has a maximum visibility of 10 km (6.2 miles) while open-meteo does not appear to have a maximum. To be consistent, should the visibility from open-meteo be capped at the same 10 km (6.2 miles)?