### PR TITLE
Suggestion: allow save another instance when editing

### DIFF
--- a/src/templates/plugin.html
+++ b/src/templates/plugin.html
@@ -357,6 +357,7 @@
             <div class="buttons-container">
                 {% if plugin_instance %}
                     <button type="button" onclick="handleAction('update_instance')" class="action-button">Save</button>
+                    <button type="button" onclick="openModal('scheduleModal')" class="action-button right">Save As...</button>
                 {% else %}
                     <button type="button" onclick="handleAction()" class="action-button left">Update Now</button>
                     <button type="button" onclick="openModal('scheduleModal')" class="action-button right">Add to Playlist</button>


### PR DESCRIPTION
This pull request introduces a new "Save As..." button to the plugin details page when editing an existing plugin instance. This provides users with an additional option to save the current plugin instance under a new configuration or name.

<img width="352" height="320" alt="image" src="https://github.com/user-attachments/assets/38e2f7f2-a646-4c11-b135-44028888498c" />


User interface enhancements:

* Added a "Save As..." button (which opens the `scheduleModal`) next to the existing "Save" button for plugin instances in the `plugin.html` template.
