### PR TITLE
Add libheif-dev to required packages to allow install on 32-bit editions of RPi OS

### DIFF
--- a/install/debian-requirements.txt
+++ b/install/debian-requirements.txt
@@ -10,3 +10,4 @@ libfreetype6-dev
 fonts-noto-color-emoji
 swig
 liblgpio-dev
+libheif-dev


### PR DESCRIPTION
The Python package `pi-heif` is currently missing from the [PiWheels ](https://www.piwheels.org/) Python repository which 32-bit editions of Raspberry Pi OS rely on for binary Python packages.:

https://www.piwheels.org/project/pi-heif/
https://github.com/piwheels/packages/issues/603

This results in PIP attempting to compile `pi-heif` locally, which fails due to `libheif-dev` being missing.

This PR adds `libheif-dev` as a required package, which should result in a better experience for those using 32-bit editions of Raspberry Pi OS, and reduce the number of issues being reported.

64-bit editions of Raspberry Pi OS are unaffected as a 64-bit binary package is available at PiPy: https://pypi.org/project/pi-heif/


