### PR TITLE
Modify Inky display saturation to 0 from the default of 0.5

### DIFF
--- a/src/display/inky_display.py
+++ b/src/display/inky_display.py
@@ -57,6 +57,7 @@ class InkyDisplay(AbstractDisplay):
         if not image:
             raise ValueError(f"No image provided.")
 
-        # Display the image on the Inky display
-        self.inky_display.set_image(image)
+        # Display the image on the Inky display - saturation set to 0 as it's not really saturation:
+        # https://github.com/pimoroni/inky/issues/225#issuecomment-3213935144
+        self.inky_display.set_image(image,saturation=0)
         self.inky_display.show()


### PR DESCRIPTION
As per feature request https://github.com/fatihak/InkyPi/issues/502.

The PR modifies the Inky display driver's 'saturation' from the default of 0.5 to 0.

The 'saturation' parameter is not really saturation, but rather a parameter that affects how the colour palette is blended between the original values and 'desaturated' values.

Originally noticed and discussed here: https://github.com/fatihak/InkyPi/issues/111

I believe a 'saturation' value of 0 results in a better image displayed on the Inky Impression screens in the vast majority of situations.