### PR TITLE
Check for static path to avoid traversal

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -73,7 +73,7 @@ def image(plugin_id, filename):
 
     # Security check to prevent directory traversal
     safe_path = os.path.abspath(os.path.join(plugin_dir, filename))
-    if not safe_path.startswith(os.path.abspath(plugin_dir)):
+    if not safe_path.startswith(os.path.abspath(plugins_dir)):
         return "Invalid path", 403
 
     # Convert to absolute path for send_from_directory


### PR DESCRIPTION
`plugin_dir` is constructed from `plugin_id`, which is part of the URL.