### PR TITLE
Add a check for Google Chrome's default macOS installation path + test

### DIFF
--- a/src/utils/image_utils.py
+++ b/src/utils/image_utils.py
@@ -114,6 +114,13 @@ def _find_chromium_binary():
         if path:
             logger.debug(f"Found browser binary: {candidate} at {path}")
             return candidate
+    
+    # Check default macOS location for Google Chrome
+    macos_chrome = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    if os.path.exists(macos_chrome):
+        logger.debug(f"Found Google Chrome at {macos_chrome}")
+        return macos_chrome
+
     return None
 
 

--- a/tests/utils/test_image_utils.py
+++ b/tests/utils/test_image_utils.py
@@ -1,0 +1,8 @@
+from unittest.mock import patch
+from src.utils.image_utils import _find_chromium_binary
+
+def test_find_chromium_binary_macos():
+    macos_path = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    with patch('shutil.which', return_value=None), \
+         patch('os.path.exists', side_effect=lambda p: p == macos_path):
+        assert _find_chromium_binary() == macos_path


### PR DESCRIPTION
### Description
This PR improves the browser discovery logic by adding the default macOS installation path for Google Chrome /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

### Changes
- **src/utils/image_utils.py**: Updated [_find_chromium_binary](cci:1://file:///Users/valentin/Documents/code.nosync/perso/InkyPi/src/utils/image_utils.py:108:0-123:15) to check the standard macOS Chrome location as a fallback.
- **tests/utils/test_image_utils.py**: Added a minimalist unit test to verify that the macOS path is correctly discovered when other options are unavailable.

### Verification Results
- [x] Verified binary discovery on macOS (Chrome found at expected path).
- [x] Ran the full test suite (including the new test).

### Impact
This change improves the experience for contributors developing on macOS without requiring manual PATH configuration for Chrome.