### PR TITLE
Update pip install commands to use piwheels

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -208,14 +208,14 @@ setup_earlyoom_service() {
 create_venv(){
   echo "Creating python virtual environment. "
   python3 -m venv "$VENV_PATH"
-  $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null
-  $VENV_PATH/bin/python -m pip install -r $PIP_REQUIREMENTS_FILE -qq > /dev/null &
+  $VENV_PATH/bin/python -m pip install --extra-index-url https://www.piwheels.org/simple --upgrade pip setuptools wheel > /dev/null
+  $VENV_PATH/bin/python -m pip install --extra-index-url https://www.piwheels.org/simple -r $PIP_REQUIREMENTS_FILE -qq > /dev/null &
   show_loader "\tInstalling python dependencies. "
 
   # do additional dependencies for Waveshare support.
   if [[ -n "$WS_TYPE" ]]; then
     echo "Adding additional dependencies for waveshare to the python virtual environment. "
-    $VENV_PATH/bin/python -m pip install -r $WS_REQUIREMENTS_FILE > ws_pip_install.log &
+    $VENV_PATH/bin/python -m pip install --extra-index-url https://www.piwheels.org/simple -r $WS_REQUIREMENTS_FILE > ws_pip_install.log &
     show_loader "\tInstalling additional Waveshare python dependencies. "
   fi
 


### PR DESCRIPTION
my raspberry pi zero could never finish the install script (stuck on Installing python dependencies.  [/], was it building from source?). I waited ~16 hours. by using pywheels, it finishes in a few minutes.