### PR TITLE
feat: Home Assistant Addon ingress compatiability

### DIFF
--- a/src/templates/playlist.html
+++ b/src/templates/playlist.html
@@ -127,7 +127,7 @@
             const img = document.getElementById('thumbnailPreviewImage');
             const info = document.getElementById('thumbnailPreviewInfo');
 
-            const imageUrl = `/plugin_instance_image/${encodeURIComponent(playlistName)}/${encodeURIComponent(pluginId)}/${encodeURIComponent(instanceName)}`;
+            const imageUrl = `{{ url_for('plugin.plugin_instance_image', playlist_name='__PL__', plugin_id='__PI__', instance_name='__IN__') }}`.replace('__PL__', encodeURIComponent(playlistName)).replace('__PI__', encodeURIComponent(pluginId)).replace('__IN__', encodeURIComponent(instanceName));
             img.src = imageUrl;
             info.textContent = `Plugin: ${pluginName} | Instance: ${instanceName}`;
             modal.style.display = 'block';


### PR DESCRIPTION
 - Add IngressMiddleware that reads X-Ingress-Path header to set SCRIPT_NAME, making all url_for() calls automatically prefix the ingress base path
 - Fix hardcoded /plugin_instance_image/ URL in playlist.html to use url_for() instead
 - Works transparently for both direct access and HA ingress
- Support PORT env var for configurable listen port

Changes required to allow running both outside **AND** inside a Home Assistant ingress path where content is served from a baseURL something like this `/api/hassio_ingress/<random uuid>/` rather than `/`:
<img width="50%" src="https://github.com/user-attachments/assets/2d53c3d0-4f60-434a-9854-5b65585b23d4" />
