### PR TITLE
plugin blueprint registration

### DIFF
--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -31,7 +31,7 @@ from blueprints.plugin import plugin_bp
 from blueprints.playlist import playlist_bp
 from blueprints.apikeys import apikeys_bp
 from jinja2 import ChoiceLoader, FileSystemLoader
-from plugins.plugin_registry import load_plugins
+from plugins.plugin_registry import load_plugins, get_plugin_instance, register_plugin_blueprints
 from waitress import serve
 
 
@@ -81,6 +81,9 @@ app.register_blueprint(plugin_bp)
 app.register_blueprint(playlist_bp)
 app.register_blueprint(apikeys_bp)
 
+
+# Register blueprints from plugins (generic mechanism - any plugin can expose blueprints)
+register_plugin_blueprints(app)
 # Register opener for HEIF/HEIC images
 register_heif_opener()
 

--- a/src/plugins/plugin_registry.py
+++ b/src/plugins/plugin_registry.py
@@ -50,3 +50,22 @@ def get_plugin_instance(plugin_config):
         return plugin_class
     else:
         raise ValueError(f"Plugin '{plugin_id}' is not registered.")
+
+def register_plugin_blueprints(app):
+    """Register blueprints from plugins that expose them via get_blueprint() method.
+    
+    This is a generic mechanism that allows any plugin to register Flask blueprints
+    by implementing a get_blueprint() class method that returns a Blueprint instance.
+    
+    Args:
+        app: Flask application instance to register blueprints with
+    """
+    for plugin_id, plugin_instance in PLUGIN_CLASSES.items():
+        try:
+            if hasattr(plugin_instance, 'get_blueprint'):
+                bp = plugin_instance.get_blueprint()
+                if bp:
+                    app.register_blueprint(bp)
+                    logger.info(f"Registered blueprint for plugin '{plugin_id}'")
+        except Exception as e:
+            logger.warning(f"Failed to register blueprint for plugin '{plugin_id}': {e}")


### PR DESCRIPTION
This PR contains the changes of my plugin-manger's core-patch.
It make two small additions to the core:
1. src/plugins/plugin_registry.py
   Add a single function `register_plugin_blueprints(app)` that:
   - Iterates over all loaded plugin instances
   - For each plugin that implements `get_blueprint()`, calls it and registers the returned Flask Blueprint with the app
   - Logs success/failure; one failing plugin does not block others

2. src/inkypi.py
   - Import `register_plugin_blueprints`
   - After registering core blueprints and before starting the server, call `register_plugin_blueprints(app)`

With this plugins are able to register their own routes which opens a lot of possibilities to implement plugins that are not possible without that. (e.g. managing assets, like the pluginManager, remote control and automation with web-hooks and push functionality, admin plugins to interact with other processes or services).

It is a minimal change to the core, adding very little but allowing complex plugins. It is backwards compatible, plugins can just ignore it.

Complexity lives in plugins, not core.

Any “clever” or powerful behavior (REST APIs, webhooks, custom endpoints) is implemented inside the plugin’s Blueprint and its own modules.
Core does not gain new concepts (e.g. “plugin APIs,” “plugin webhooks”) beyond “plugins may register one Blueprint.”

**edit**

Here is a simple [poc](https://github.com/RobinWts/pisugarbutton_poc) plugin that uses the registration to add a route to force the currently displayed instance to refresh, it is intended to be called, for example by the PiSugar service but it could easily be called by a script monitoring GPIO pins to add other buttons (this could be set by the settings inside the InkyPi UI which is empty for now) or an automation like NodeRed - yes I am aware that this could also be done by creating a script that finds out what's running from device.json and call /display_plugin_instance with the accuired info but this is a much more stable and less hacky way that is usable for users who do not dive in that deep...