### PR TITLE
feat(image_url): add configurable timeout setting for image downloads

### DIFF
--- a/src/plugins/image_url/image_url.py
+++ b/src/plugins/image_url/image_url.py
@@ -20,8 +20,13 @@ class ImageURL(BasePlugin):
         logger.info(f"Fetching image from URL: {url}")
         logger.debug(f"Target dimensions: {dimensions[0]}x{dimensions[1]}")
 
+        # Get timeout from settings, convert seconds to milliseconds
+        timeout_seconds = settings.get('timeout', 40)
+        timeout_ms = int(timeout_seconds * 1000)
+        logger.debug(f"Timeout: {timeout_seconds} seconds ({timeout_ms} ms)")
+
         # Use adaptive image loader for memory-efficient processing
-        image = self.image_loader.from_url(url, dimensions, timeout_ms=40000)
+        image = self.image_loader.from_url(url, dimensions, timeout_ms=timeout_ms)
 
         if not image:
             logger.error("Failed to load image from URL")

--- a/src/plugins/image_url/settings.html
+++ b/src/plugins/image_url/settings.html
@@ -4,6 +4,12 @@
 </div>
 
 <div class="form-group">
+    <label for="timeout" class="form-label">Timeout (seconds):</label>
+    <input type="number" id="timeout" name="timeout" placeholder="40" min="1" class="form-input">
+    <small class="form-hint">Maximum time to wait for image download (default: 40 seconds)</small>
+</div>
+
+<div class="form-group">
     <span style="color: var(--text-primary);">Warning: Do not run with untrusted URLs, as it may pose a security risk. This may also fail if the image takes too long to load.</span>
 </div>
 
@@ -12,6 +18,7 @@
     document.addEventListener('DOMContentLoaded', () => {        
         if (loadPluginSettings) {
             document.getElementById('url').value = pluginSettings.url;
+            document.getElementById('timeout').value = pluginSettings.timeout || '';
         }
     });
 </script>


### PR DESCRIPTION
Ads a field in the image_url plugin that allows the timeout to be customised.

This allows users who self host image generation to have a longer timeout allowing their machines to generate the image before the request times out.