### PR TITLE
Reintroduce immich permissions fix for shared albums

### DIFF
--- a/src/plugins/image_album/image_album.py
+++ b/src/plugins/image_album/image_album.py
@@ -30,28 +30,15 @@ class ImmichProvider:
         return matching_albums[0]["id"]
 
     def get_assets(self, album_id: str) -> list[dict]:
-        """Fetch all assets from album."""
-        all_items = []
-        page_items = [1]
-        page = 1
+        """Fetch all assets from album using the album details endpoint."""
+        logger.debug(f"Fetching assets from album {album_id} via /api/albums/{album_id}")
+        r2 = self.session.get(f"{self.base_url}/api/albums/{album_id}", headers=self.headers)
+        r2.raise_for_status()
+        album_data = r2.json()
 
-        logger.debug(f"Fetching assets from album {album_id}")
-        while page_items:
-            body = {
-                "albumIds": [album_id],
-                "size": 1000,
-                "page": page
-            }
-            r2 = self.session.post(f"{self.base_url}/api/search/metadata", json=body, headers=self.headers)
-            r2.raise_for_status()
-            assets_data = r2.json()
-
-            page_items = assets_data.get("assets", {}).get("items", [])
-            all_items.extend(page_items)
-            page += 1
-
-        logger.debug(f"Found {len(all_items)} total assets in album")
-        return all_items
+        assets = album_data.get("assets", []) or []
+        logger.debug(f"Found {len(assets)} total assets in album")
+        return assets
 
     def get_image(self, album: str, dimensions: tuple[int, int], resize: bool = True) -> Image.Image | None:
         """


### PR DESCRIPTION
## What happened
**#469** (Fix Immich permissions issue for shared albums) correctly fixed shared albums by fetching assets via `GET /api/albums/{id}` and using the response `assets` array, so all album members’ photos were included.

In **#427** (Image memory optimization), the plugin was refactored (new image loader, `get_album_id` + `get_assets`, etc.). During that refactor, asset listing was switched back to `POST /api/search/metadata` with `albumIds`, and the #469 behavior was effectively reverted. So the fix was already there; it was removed by mistake.

## Resulting bug
For shared albums, the plugin once again only sees assets owned by the API key user. The UI shows the full album (e.g. 33 photos), but the plugin only receives a subset (e.g. 5). As a result, “random” selection is limited and the same photos repeat.

I believe this is a very common scenario. For example, I created the album using my account and uploaded some photos, but the majority were uploaded by my girlfriend with a different account.

## This PR
Restores the #469 approach for **listing** assets: use `GET /api/albums/{albumId}` and `album.get("assets", [])` again. All of #427’s improvements are kept (streaming, resize, image loader) only the source of the asset list is reverted to the endpoint that returns the full album, including shared contributors. No change to how images are loaded, so the OOM fix from #427 should remain in place.
