### PR TITLE
Fix installer hangs and harden dependency/setup error handling

### DIFF
--- a/install/debian-requirements.txt
+++ b/install/debian-requirements.txt
@@ -5,10 +5,12 @@ python3-pip
 avahi-daemon
 libopenblas-dev
 libopenjp2-7
+libjpeg-dev
 chromium-headless-shell
 libfreetype6-dev
 fonts-noto-color-emoji
 swig
 liblgpio-dev
 libheif-dev
+pkg-config
 jq

--- a/install/install.sh
+++ b/install/install.sh
@@ -151,15 +151,23 @@ show_loader() {
 
   local delay=0.1
   local spinstr='|/-\'
-  printf "$message [${spinstr:0:1}] "
+  printf '%s [%s] ' "$message" "${spinstr:0:1}"
   while kill -0 "$pid" 2>/dev/null; do
     local temp=${spinstr#?}
-    printf "\r$message [${temp:0:1}] "
+    printf '\r%s [%s] ' "$message" "${temp:0:1}"
     spinstr=${temp}${spinstr%"${temp}"}
     sleep ${delay}
   done
 
-  printf "\r$message [\e[32m\xE2\x9C\x94\e[0m]\n"
+  wait "$pid"
+  local status=$?
+  if [[ $status -eq 0 ]]; then
+    printf '\r%s [\e[32m\xE2\x9C\x94\e[0m]\n' "$message"
+  else
+    printf '\r%s [\e[31m\xE2\x9C\x98\e[0m]\n' "$message"
+  fi
+
+  return "$status"
 }
 
 echo_success() {
@@ -291,12 +299,12 @@ install_config() {
   CONFIG_DIR="$SRC_PATH/config"
   echo "Copying config files to $CONFIG_DIR"
 
-  # Check and copy device.config if it doesn't exist
+  # Check and copy device.json if it doesn't exist
   if [ ! -f "$CONFIG_DIR/device.json" ]; then
     if cp "$CONFIG_BASE_DIR/device.json" "$CONFIG_DIR/"; then
-      echo_success "\tCopying device.config to $CONFIG_DIR"
+      echo_success "\tCopying device.json to $CONFIG_DIR"
     else
-      echo_error "ERROR: Failed to copy device.config to $CONFIG_DIR"
+      echo_error "ERROR: Failed to copy device.json to $CONFIG_DIR"
       exit 1
     fi
   else
@@ -335,7 +343,10 @@ stop_service() {
     then
       /usr/bin/systemctl stop $SERVICE_FILE > /dev/null &
       local stop_pid=$!
-      show_loader "Stopping $APPNAME service" "$stop_pid"
+      if ! show_loader "Stopping $APPNAME service" "$stop_pid"; then
+        echo_error "ERROR: Failed to stop $SERVICE_FILE"
+        exit 1
+      fi
     else  
       echo_success "\t$SERVICE_FILE not running"
     fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -141,21 +141,25 @@ enable_interfaces(){
 }
 
 show_loader() {
-  local pid=$!
+  local message="$1"
+  local pid="${2:-$!}"
+
+  if [[ -z "$pid" ]]; then
+    echo_success "$message"
+    return 0
+  fi
+
   local delay=0.1
   local spinstr='|/-\'
-  printf "$1 [${spinstr:0:1}] "
-  while ps a | awk '{print $1}' | grep -q "${pid}"; do
+  printf "$message [${spinstr:0:1}] "
+  while kill -0 "$pid" 2>/dev/null; do
     local temp=${spinstr#?}
-    printf "\r$1 [${temp:0:1}] "
+    printf "\r$message [${temp:0:1}] "
     spinstr=${temp}${spinstr%"${temp}"}
     sleep ${delay}
   done
-  if [[ $? -eq 0 ]]; then
-    printf "\r$1 [\e[32m\xE2\x9C\x94\e[0m]\n"
-  else
-    printf "\r$1 [\e[31m\xE2\x9C\x98\e[0m]\n"
-  fi
+
+  printf "\r$message [\e[32m\xE2\x9C\x94\e[0m]\n"
 }
 
 echo_success() {
@@ -289,8 +293,12 @@ install_config() {
 
   # Check and copy device.config if it doesn't exist
   if [ ! -f "$CONFIG_DIR/device.json" ]; then
-    cp "$CONFIG_BASE_DIR/device.json" "$CONFIG_DIR/"
-    show_loader "\tCopying device.config to $CONFIG_DIR"
+    if cp "$CONFIG_BASE_DIR/device.json" "$CONFIG_DIR/"; then
+      echo_success "\tCopying device.config to $CONFIG_DIR"
+    else
+      echo_error "ERROR: Failed to copy device.config to $CONFIG_DIR"
+      exit 1
+    fi
   else
     echo_success "\tdevice.json already exists in $CONFIG_DIR"
   fi
@@ -326,7 +334,8 @@ stop_service() {
     if /usr/bin/systemctl is-active --quiet $SERVICE_FILE
     then
       /usr/bin/systemctl stop $SERVICE_FILE > /dev/null &
-      show_loader "Stopping $APPNAME service"
+      local stop_pid=$!
+      show_loader "Stopping $APPNAME service" "$stop_pid"
     else  
       echo_success "\t$SERVICE_FILE not running"
     fi
@@ -341,14 +350,22 @@ install_src() {
   # Check if an existing installation is present
   echo "Installing $APPNAME to $INSTALL_PATH"
   if [[ -d $INSTALL_PATH ]]; then
-    rm -rf "$INSTALL_PATH" > /dev/null
-    show_loader "\tRemoving existing installation found at $INSTALL_PATH"
+    if rm -rf "$INSTALL_PATH" > /dev/null; then
+      echo_success "\tRemoving existing installation found at $INSTALL_PATH"
+    else
+      echo_error "ERROR: Failed to remove existing installation at $INSTALL_PATH"
+      exit 1
+    fi
   fi
 
   mkdir -p "$INSTALL_PATH"
 
-  ln -sf "$SRC_PATH" "$INSTALL_PATH/src"
-  show_loader "\tCreating symlink from $SRC_PATH to $INSTALL_PATH/src"
+  if ln -sf "$SRC_PATH" "$INSTALL_PATH/src"; then
+    echo_success "\tCreating symlink from $SRC_PATH to $INSTALL_PATH/src"
+  else
+    echo_error "ERROR: Failed to create symlink from $SRC_PATH to $INSTALL_PATH/src"
+    exit 1
+  fi
 }
 
 install_cli() {

--- a/install/install.sh
+++ b/install/install.sh
@@ -181,11 +181,30 @@ echo_blue() {
 
 install_debian_dependencies() {
   if [ -f "$APT_REQUIREMENTS_FILE" ]; then
-    sudo apt-get update > /dev/null &
-    show_loader "Fetch available system dependencies updates. " 
+    echo "Repairing interrupted package operations (if any)."
+    if ! sudo dpkg --configure -a; then
+      echo_error "ERROR: Failed to repair interrupted dpkg state. Please run 'sudo dpkg --configure -a' manually."
+      exit 1
+    fi
 
-    xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null &
-    show_loader "Installing system dependencies. "
+    if ! sudo apt-get -f install -y > /dev/null; then
+      echo_error "ERROR: apt failed to repair broken dependencies."
+      exit 1
+    fi
+
+    echo "Fetching available system dependency updates."
+    if ! sudo apt-get update > /dev/null; then
+      echo_error "ERROR: Failed to fetch package updates via apt-get update."
+      exit 1
+    fi
+    echo_success "\tSystem package index updated"
+
+    echo "Installing system dependencies."
+    if ! xargs -a "$APT_REQUIREMENTS_FILE" sudo apt-get install -y > /dev/null; then
+      echo_error "ERROR: Failed to install one or more system dependencies from $APT_REQUIREMENTS_FILE"
+      exit 1
+    fi
+    echo_success "\tSystem dependencies installed"
   else
     echo "ERROR: System dependencies file $APT_REQUIREMENTS_FILE not found!"
     exit 1
@@ -194,29 +213,53 @@ install_debian_dependencies() {
 
 setup_zramswap_service() {
   echo "Enabling and starting zramswap service."
-  sudo apt-get install -y zram-tools > /dev/null
+  if ! sudo apt-get install -y zram-tools > /dev/null; then
+    echo_error "ERROR: Failed to install zram-tools."
+    exit 1
+  fi
   echo -e "ALGO=zstd\nPERCENT=60" | sudo tee /etc/default/zramswap > /dev/null
-  sudo systemctl enable --now zramswap
+  if ! sudo systemctl enable --now zramswap; then
+    echo_error "ERROR: Failed to enable/start zramswap service."
+    exit 1
+  fi
 }
 
 setup_earlyoom_service() {
   echo "Enabling and starting earlyoom service."
-  sudo apt-get install -y earlyoom > /dev/null
-  sudo systemctl enable --now earlyoom
+  if ! sudo apt-get install -y earlyoom > /dev/null; then
+    echo_error "ERROR: Failed to install earlyoom package."
+    exit 1
+  fi
+
+  if ! sudo systemctl enable --now earlyoom; then
+    echo_error "ERROR: Failed to enable/start earlyoom service."
+    exit 1
+  fi
 }
 
 create_venv(){
   echo "Creating python virtual environment. "
   python3 -m venv "$VENV_PATH"
-  $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null
-  $VENV_PATH/bin/python -m pip install -r $PIP_REQUIREMENTS_FILE -qq > /dev/null &
-  show_loader "\tInstalling python dependencies. "
+  if ! $VENV_PATH/bin/python -m pip install --upgrade pip setuptools wheel > /dev/null; then
+    echo_error "ERROR: Failed to upgrade pip tooling inside virtual environment."
+    exit 1
+  fi
+
+  echo "Installing python dependencies."
+  if ! $VENV_PATH/bin/python -m pip install -r "$PIP_REQUIREMENTS_FILE" -qq > /dev/null; then
+    echo_error "ERROR: Failed to install Python dependencies from $PIP_REQUIREMENTS_FILE"
+    exit 1
+  fi
+  echo_success "\tPython dependencies installed"
 
   # do additional dependencies for Waveshare support.
   if [[ -n "$WS_TYPE" ]]; then
     echo "Adding additional dependencies for waveshare to the python virtual environment. "
-    $VENV_PATH/bin/python -m pip install -r $WS_REQUIREMENTS_FILE > ws_pip_install.log &
-    show_loader "\tInstalling additional Waveshare python dependencies. "
+    if ! $VENV_PATH/bin/python -m pip install -r "$WS_REQUIREMENTS_FILE" > ws_pip_install.log; then
+      echo_error "ERROR: Failed to install Waveshare Python dependencies from $WS_REQUIREMENTS_FILE"
+      exit 1
+    fi
+    echo_success "\tAdditional Waveshare python dependencies installed"
   fi
 
 }


### PR DESCRIPTION
### Why
Installer runs could appear stuck (notably around symlink creation) because the progress spinner sometimes tracked an invalid/stale process ID.
The install flow also had limited recovery/reporting for interrupted package operations and setup failures.

### What changed
Updated spinner logic to track an explicit PID and use reliable process checks.
Removed spinner usage for foreground commands and replaced it with direct success/failure checks.
Added recovery for interrupted/broken package state before dependency install.
Added fail-fast error handling for apt installs, service enable/start steps, venv tooling, and Python dependency installs.
Added explicit success/error handling for config copy, install path cleanup, and source symlink creation.
Added required Debian packages to improve native/image dependency builds during install.

### Result
Prevents false “stuck” states during install.
Improves reliability on partially broken systems.
Produces clearer, actionable errors when a step fails.