### PR TITLE
Fix: scheduled refresh and stale image

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -308,14 +308,6 @@ class PluginInstance:
         # Check for scheduled refresh (HH:MM format)
         if "scheduled" in self.refresh:
             scheduled_time_str = self.refresh.get("scheduled")
-            latest_refresh_str = latest_refresh_dt.strftime("%H:%M")
-
-            # If the latest refresh is before the scheduled time today
-            if latest_refresh_str < scheduled_time_str:
-                return True
-        
-        if "scheduled" in self.refresh:
-            scheduled_time_str = self.refresh.get("scheduled")
             scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
             
             latest_refresh_date = latest_refresh_dt.date()

--- a/src/model.py
+++ b/src/model.py
@@ -296,7 +296,13 @@ class PluginInstance:
     def should_refresh(self, current_time):
         """Checks whether the plugin should be refreshed based on its refresh settings and the current time."""
         latest_refresh_dt = self.get_latest_refresh_dt()
+
+        # If never refreshed, check scheduled time before allowing refresh
         if not latest_refresh_dt:
+            if "scheduled" in self.refresh:
+                scheduled_time_str = self.refresh.get("scheduled")
+                scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
+                return current_time.time() >= scheduled_time
             return True
 
         # Check for interval-based refresh

--- a/src/plugins/clock/clock.py
+++ b/src/plugins/clock/clock.py
@@ -38,7 +38,7 @@ CLOCK_FACES = [
     }
 ]
 
-DEFAULT_TIMEZONE = "UTC"
+DEFAULT_TIMEZONE = "US/Eastern"
 DEFAULT_CLOCK_FACE = "Gradient Clock"
 
 class Clock(BasePlugin):

--- a/src/plugins/clock/clock.py
+++ b/src/plugins/clock/clock.py
@@ -38,7 +38,7 @@ CLOCK_FACES = [
     }
 ]
 
-DEFAULT_TIMEZONE = "US/Eastern"
+DEFAULT_TIMEZONE = "UTC"
 DEFAULT_CLOCK_FACE = "Gradient Clock"
 
 class Clock(BasePlugin):

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -112,6 +112,12 @@ class RefreshTask:
                             continue
                         plugin = get_plugin_instance(plugin_config)
                         image = refresh_action.execute(plugin, self.device_config, current_dt)
+
+                        # If execute returns None, the plugin was skipped (not time to refresh)
+                        if image is None:
+                            self.device_config.write_config()
+                            continue
+
                         image_hash = compute_image_hash(image)
 
                         refresh_info = refresh_action.get_refresh_info()
@@ -280,9 +286,8 @@ class PlaylistRefresh(RefreshAction):
             image.save(plugin_image_path)
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
         else:
-            logger.info(f"Not time to refresh plugin instance, using latest image. | plugin_instance: {self.plugin_instance.name}.")
-            # Load the existing image from disk
-            with Image.open(plugin_image_path) as img:
-                image = img.copy()
+            logger.info(f"Not time to refresh plugin instance, skipping. | plugin_instance: {self.plugin_instance.name}.")
+            # Return None to signal that this plugin should be skipped
+            return None
 
         return image

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -103,7 +103,7 @@ class RefreshTask:
                         logger.info(f"Running interval refresh check. | current_time: {current_dt.strftime('%Y-%m-%d %H:%M:%S')}")
                         playlist, plugin_instance = self._determine_next_plugin(playlist_manager, latest_refresh, current_dt)
                         if plugin_instance:
-                            refresh_action = PlaylistRefresh(playlist, plugin_instance)
+                            refresh_action = PlaylistRefresh(playlist, plugin_instance, force=True)
 
                     if refresh_action:
                         plugin_config = self.device_config.get_plugin(refresh_action.get_plugin_id())
@@ -188,10 +188,18 @@ class RefreshTask:
             logger.info(f"Not time to update display. | latest_update: {latest_refresh_str} | plugin_cycle_interval: {plugin_cycle_interval}")
             return None, None
 
-        plugin = playlist.get_next_plugin()
-        logger.info(f"Determined next plugin. | active_playlist: {playlist.name} | plugin_instance: {plugin.name}")
+        # Loop through all plugins in the playlist to find one that needs refreshing
+        num_plugins = len(playlist.plugins)
+        for _ in range(num_plugins):
+            plugin = playlist.get_next_plugin()
+            if plugin.should_refresh(current_dt):
+                logger.info(f"Determined next plugin. | active_playlist: {playlist.name} | plugin_instance: {plugin.name}")
+                return playlist, plugin
+            else:
+                logger.info(f"Plugin '{plugin.name}' not due for refresh, skipping.")
 
-        return playlist, plugin
+        logger.info(f"No plugins in playlist '{playlist.name}' need refreshing.")
+        return None, None
     
     def log_system_stats(self):
         metrics = {

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -115,6 +115,11 @@ class RefreshTask:
 
                         # If execute returns None, the plugin was skipped (not time to refresh)
                         if image is None:
+                            # Revert playlist index so this plugin is retried next cycle
+                            if isinstance(refresh_action, PlaylistRefresh):
+                                playlist = refresh_action.playlist
+                                if playlist.current_plugin_index is not None:
+                                    playlist.current_plugin_index = (playlist.current_plugin_index - 1) % len(playlist.plugins)
                             self.device_config.write_config()
                             continue
 

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -115,11 +115,6 @@ class RefreshTask:
 
                         # If execute returns None, the plugin was skipped (not time to refresh)
                         if image is None:
-                            # Revert playlist index so this plugin is retried next cycle
-                            if isinstance(refresh_action, PlaylistRefresh):
-                                playlist = refresh_action.playlist
-                                if playlist.current_plugin_index is not None:
-                                    playlist.current_plugin_index = (playlist.current_plugin_index - 1) % len(playlist.plugins)
                             self.device_config.write_config()
                             continue
 
@@ -288,6 +283,9 @@ class PlaylistRefresh(RefreshAction):
             logger.info(f"Refreshing plugin instance. | plugin_instance: '{self.plugin_instance.name}'") 
             # Generate a new image
             image = plugin.generate_image(self.plugin_instance.settings, device_config)
+            if image is None:
+                logger.error(f"Plugin '{self.plugin_instance.name}' returned no image. Skipping.")
+                return None
             image.save(plugin_image_path)
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
         else:

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -75,7 +75,11 @@
 
         <!-- Display the current image -->
         <div class="image-container">
-            <img src="{{ url_for('static', filename='images/current_image.png') }}" alt="Current Image">
+            <img src="{{ url_for('static', filename='images/current_image.png') }}" alt="Current Image"
+                 onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+            <div style="display:none; width:100%; aspect-ratio:5/3; background:var(--bg-secondary, #f0f0f0); border-radius:8px; align-items:center; justify-content:center; color:var(--text-secondary, #888); font-size:14px;">
+                No image displayed yet
+            </div>
         </div>
 
         <!-- Separator -->


### PR DESCRIPTION
**Description**

This PR improves the refresh logic and fixes stability issues in InkyPi.

**Changes**

- Process all plugins in the active playlist each cycle
- Fix playlist iteration getting stuck on a single plugin
- Ensure scheduled and interval plugins refresh at the correct time
- Prevent crash when a plugin returns no image
- Add error handling and clearer logging for failed plugins
- Add placeholder to avoid broken image on first load

**Impact**

- More reliable and responsive refresh behavior
- No crashes when plugin image generation fails
- Better handling of initial and error states




<img width="1603" height="741" alt="2026-03-19_16-02" src="https://github.com/user-attachments/assets/dc739921-c28a-4283-b2aa-8ee013343784" />


<img width="1074" height="879" alt="2026-03-19_17-15" src="https://github.com/user-attachments/assets/7390f6bf-47f3-42ed-8367-824ccfa0aad5" />
