### PR TITLE
Fix scheduled refresh not updating correctly and broken default image on first load

### DIFF
--- a/src/blueprints/plugin.py
+++ b/src/blueprints/plugin.py
@@ -249,6 +249,8 @@ def update_now():
 
             plugin = get_plugin_instance(plugin_config)
             image = plugin.generate_image(plugin_settings, device_config)
+            if image is None:
+                return jsonify({"error": f"Plugin '{plugin_id}' failed to generate an image."}), 500
             display_manager.display_image(image, image_settings=plugin_config.get("image_settings", []))
 
     except Exception as e:

--- a/src/model.py
+++ b/src/model.py
@@ -308,14 +308,6 @@ class PluginInstance:
         # Check for scheduled refresh (HH:MM format)
         if "scheduled" in self.refresh:
             scheduled_time_str = self.refresh.get("scheduled")
-            latest_refresh_str = latest_refresh_dt.strftime("%H:%M")
-
-            # If the latest refresh is before the scheduled time today
-            if latest_refresh_str < scheduled_time_str:
-                return True
-        
-        if "scheduled" in self.refresh:
-            scheduled_time_str = self.refresh.get("scheduled")
             scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
             
             latest_refresh_date = latest_refresh_dt.date()

--- a/src/model.py
+++ b/src/model.py
@@ -307,7 +307,13 @@ class PluginInstance:
                 if current_time.tzinfo is not None:
                     scheduled_dt = scheduled_dt.replace(tzinfo=current_time.tzinfo)
 
-                return current_time >= scheduled_dt
+                result = current_time >= scheduled_dt
+                logger.debug(
+                    f"should_refresh({self.name}): never refreshed, scheduled={scheduled_time_str}, "
+                    f"current_time={current_time}, result={result}"
+                )
+                return result
+            logger.debug(f"should_refresh({self.name}): never refreshed, no schedule, returning True")
             return True
 
         # Check for interval-based refresh
@@ -323,7 +329,12 @@ class PluginInstance:
                 elif ldt.tzinfo is not None and current_time.tzinfo is not None:
                     ldt = ldt.astimezone(current_time.tzinfo)
 
-                if (current_time - ldt) >= timedelta(seconds=interval):
+                elapsed = current_time - ldt
+                if elapsed >= timedelta(seconds=interval):
+                    logger.debug(
+                        f"should_refresh({self.name}): interval elapsed "
+                        f"({elapsed.total_seconds():.0f}s >= {interval}s), returning True"
+                    )
                     return True
 
         # Check for scheduled refresh (HH:MM format)
@@ -351,8 +362,17 @@ class PluginInstance:
             # Determine if a refresh is needed based on scheduled time and last refresh
             if (latest_refresh_date < current_date and current_time >= scheduled_dt) or \
                (latest_refresh_date == current_date and ldt < scheduled_dt <= current_time):
+                logger.debug(
+                    f"should_refresh({self.name}): scheduled time reached "
+                    f"(scheduled={scheduled_time_str}, latest_refresh_date={latest_refresh_date}, "
+                    f"current_date={current_date}), returning True"
+                )
                 return True
 
+        logger.debug(
+            f"should_refresh({self.name}): no refresh needed "
+            f"| latest_refresh={latest_refresh_dt} | refresh_settings={self.refresh}"
+        )
         return False
 
     def get_image_path(self):

--- a/src/model.py
+++ b/src/model.py
@@ -296,32 +296,61 @@ class PluginInstance:
     def should_refresh(self, current_time):
         """Checks whether the plugin should be refreshed based on its refresh settings and the current time."""
         latest_refresh_dt = self.get_latest_refresh_dt()
-
         # If never refreshed, check scheduled time before allowing refresh
         if not latest_refresh_dt:
             if "scheduled" in self.refresh:
                 scheduled_time_str = self.refresh.get("scheduled")
                 scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
-                return current_time.time() >= scheduled_time
+
+                # Build a scheduled datetime on the current date and align tzinfo with current_time
+                scheduled_dt = datetime.combine(current_time.date(), scheduled_time)
+                if current_time.tzinfo is not None:
+                    scheduled_dt = scheduled_dt.replace(tzinfo=current_time.tzinfo)
+
+                return current_time >= scheduled_dt
             return True
 
         # Check for interval-based refresh
         if "interval" in self.refresh:
             interval = self.refresh.get("interval")
-            if interval and (current_time - latest_refresh_dt) >= timedelta(seconds=interval):
-                return True
+            if interval:
+                ldt = latest_refresh_dt
+                # Normalize latest refresh to current_time's tz-naive/aware state
+                if ldt.tzinfo is None and current_time.tzinfo is not None:
+                    ldt = ldt.replace(tzinfo=current_time.tzinfo)
+                elif ldt.tzinfo is not None and current_time.tzinfo is None:
+                    ldt = ldt.replace(tzinfo=None)
+                elif ldt.tzinfo is not None and current_time.tzinfo is not None:
+                    ldt = ldt.astimezone(current_time.tzinfo)
+
+                if (current_time - ldt) >= timedelta(seconds=interval):
+                    return True
 
         # Check for scheduled refresh (HH:MM format)
         if "scheduled" in self.refresh:
             scheduled_time_str = self.refresh.get("scheduled")
             scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
-            
-            latest_refresh_date = latest_refresh_dt.date()
+
+            # Build a scheduled datetime for today and align tzinfo with current_time
+            scheduled_dt = datetime.combine(current_time.date(), scheduled_time)
+            if current_time.tzinfo is not None:
+                scheduled_dt = scheduled_dt.replace(tzinfo=current_time.tzinfo)
+
+            # Normalize latest_refresh_dt into current_time's timezone/naive state for safe comparison
+            ldt = latest_refresh_dt
+            if ldt.tzinfo is None and current_time.tzinfo is not None:
+                ldt = ldt.replace(tzinfo=current_time.tzinfo)
+            elif ldt.tzinfo is not None and current_time.tzinfo is None:
+                ldt = ldt.replace(tzinfo=None)
+            elif ldt.tzinfo is not None and current_time.tzinfo is not None:
+                ldt = ldt.astimezone(current_time.tzinfo)
+
+            latest_refresh_date = ldt.date()
             current_date = current_time.date()
 
             # Determine if a refresh is needed based on scheduled time and last refresh
-            if (latest_refresh_date < current_date and current_time.time() >= scheduled_time) or \
-            (latest_refresh_date == current_date and latest_refresh_dt.time() < scheduled_time <= current_time.time()):
+            if (latest_refresh_date < current_date and current_time >= scheduled_dt) or \
+               (latest_refresh_date == current_date and ldt < scheduled_dt <= current_time):
                 return True
 
         return False

--- a/src/model.py
+++ b/src/model.py
@@ -296,7 +296,13 @@ class PluginInstance:
     def should_refresh(self, current_time):
         """Checks whether the plugin should be refreshed based on its refresh settings and the current time."""
         latest_refresh_dt = self.get_latest_refresh_dt()
+
+        # If never refreshed, check scheduled time before allowing refresh
         if not latest_refresh_dt:
+            if "scheduled" in self.refresh:
+                scheduled_time_str = self.refresh.get("scheduled")
+                scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
+                return current_time.time() >= scheduled_time
             return True
 
         # Check for interval-based refresh

--- a/src/model.py
+++ b/src/model.py
@@ -403,6 +403,8 @@ class PluginInstance:
             ldt = latest_refresh_dt
             if ldt.tzinfo is None and current_time.tzinfo is not None:
                 ldt = ldt.replace(tzinfo=current_time.tzinfo)
+            elif ldt.tzinfo is not None and current_time.tzinfo is None:
+                ldt = ldt.replace(tzinfo=None)
             elif ldt.tzinfo is not None and current_time.tzinfo is not None:
                 ldt = ldt.astimezone(current_time.tzinfo)
 
@@ -420,6 +422,8 @@ class PluginInstance:
                 ldt = latest_refresh_dt
                 if ldt.tzinfo is None and current_time.tzinfo is not None:
                     ldt = ldt.replace(tzinfo=current_time.tzinfo)
+                elif ldt.tzinfo is not None and current_time.tzinfo is None:
+                    ldt = ldt.replace(tzinfo=None)
                 elif ldt.tzinfo is not None and current_time.tzinfo is not None:
                     ldt = ldt.astimezone(current_time.tzinfo)
                 return ldt + timedelta(seconds=interval)

--- a/src/model.py
+++ b/src/model.py
@@ -375,6 +375,60 @@ class PluginInstance:
         )
         return False
 
+    def get_due_datetime(self, current_time):
+        """Computes the effective due datetime for this plugin.
+
+        For scheduled plugins: today's scheduled time (or yesterday's if the
+        plugin has never been refreshed and the scheduled time has passed).
+        For interval plugins: latest_refresh_time + interval.
+        For never-refreshed non-scheduled plugins: datetime.min (highest priority).
+
+        Returns a timezone-aware or naive datetime matching current_time.
+        """
+        latest_refresh_dt = self.get_latest_refresh_dt()
+
+        # --- scheduled ---
+        if "scheduled" in self.refresh:
+            scheduled_time_str = self.refresh.get("scheduled")
+            scheduled_time = datetime.strptime(scheduled_time_str, "%H:%M").time()
+            scheduled_dt = datetime.combine(current_time.date(), scheduled_time)
+            if current_time.tzinfo is not None:
+                scheduled_dt = scheduled_dt.replace(tzinfo=current_time.tzinfo)
+
+            if not latest_refresh_dt:
+                # Never refreshed ? due since today's scheduled time
+                return scheduled_dt
+
+            # Normalize latest_refresh_dt timezone
+            ldt = latest_refresh_dt
+            if ldt.tzinfo is None and current_time.tzinfo is not None:
+                ldt = ldt.replace(tzinfo=current_time.tzinfo)
+            elif ldt.tzinfo is not None and current_time.tzinfo is not None:
+                ldt = ldt.astimezone(current_time.tzinfo)
+
+            # If last refresh was before today's scheduled time, due time is today's scheduled time
+            if ldt < scheduled_dt <= current_time:
+                return scheduled_dt
+            # If last refresh was on a previous day, due time is today's scheduled time
+            if ldt.date() < current_time.date() and current_time >= scheduled_dt:
+                return scheduled_dt
+
+        # --- interval ---
+        if "interval" in self.refresh:
+            interval = self.refresh.get("interval")
+            if interval and latest_refresh_dt:
+                ldt = latest_refresh_dt
+                if ldt.tzinfo is None and current_time.tzinfo is not None:
+                    ldt = ldt.replace(tzinfo=current_time.tzinfo)
+                elif ldt.tzinfo is not None and current_time.tzinfo is not None:
+                    ldt = ldt.astimezone(current_time.tzinfo)
+                return ldt + timedelta(seconds=interval)
+
+        # Never refreshed, no schedule ? due since the beginning of time
+        if current_time.tzinfo is not None:
+            return datetime.min.replace(tzinfo=current_time.tzinfo)
+        return datetime.min
+
     def get_image_path(self):
         """Formats the image path for this plugin instance."""
         return f"{self.plugin_id}_{self.name.replace(' ', '_')}.png"

--- a/src/plugins/clock/clock.py
+++ b/src/plugins/clock/clock.py
@@ -38,7 +38,7 @@ CLOCK_FACES = [
     }
 ]
 
-DEFAULT_TIMEZONE = "UTC"
+DEFAULT_TIMEZONE = "US/Eastern"
 DEFAULT_CLOCK_FACE = "Gradient Clock"
 
 class Clock(BasePlugin):

--- a/src/plugins/clock/clock.py
+++ b/src/plugins/clock/clock.py
@@ -38,7 +38,7 @@ CLOCK_FACES = [
     }
 ]
 
-DEFAULT_TIMEZONE = "US/Eastern"
+DEFAULT_TIMEZONE = "UTC"
 DEFAULT_CLOCK_FACE = "Gradient Clock"
 
 class Clock(BasePlugin):

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -302,22 +302,26 @@ class PlaylistRefresh(RefreshAction):
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
             return image
 
-        # Not time to regenerate — attempt to load a cached image for display rotation.
-        logger.debug(f"Using cached image for plugin instance if available. | plugin_instance: {self.plugin_instance.name}.")
-        if os.path.exists(plugin_image_path):
-            try:
-                image = Image.open(plugin_image_path)
-                # Do not update plugin_instance.latest_refresh_time — we are using cached content.
-                return image
-            except Exception:
-                logger.exception(f"Failed to load cached image for '{self.plugin_instance.name}', will attempt regeneration.")
+        # Not time to regenerate — load and return the cached image from disk to keep
+        # playlist rotation working. Return None only for error/skip conditions.
+        logger.info(
+            f"Not time to refresh plugin instance; using cached image. | plugin_instance: {self.plugin_instance.name}."
+        )
 
-        # If cached image not present or failed to load, fall back to regenerating the image.
-        logger.debug(f"Cached image missing or unreadable; regenerating. | plugin_instance: {self.plugin_instance.name}")
-        image = plugin.generate_image(self.plugin_instance.settings, device_config)
-        if image is None:
-            logger.error(f"Plugin '{self.plugin_instance.name}' returned no image on regeneration. Skipping.")
+        if not os.path.exists(plugin_image_path):
+            logger.error(
+                f"Cached image for plugin instance is missing; cannot display. | plugin_instance: {self.plugin_instance.name} | path: {plugin_image_path}"
+            )
             return None
-        image.save(plugin_image_path)
-        self.plugin_instance.latest_refresh_time = current_dt.isoformat()
-        return image
+
+        try:
+            image = Image.open(plugin_image_path)
+            # Ensure the image data is actually loaded before returning
+            image.load()
+            # Do not update plugin_instance.latest_refresh_time — we are using cached content.
+            return image
+        except Exception as exc:
+            logger.exception(
+                f"Failed to load cached image for plugin instance; skipping. | plugin_instance: {self.plugin_instance.name}, path: {plugin_image_path}"
+            )
+            return None

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -172,10 +172,12 @@ class RefreshTask:
     def _determine_next_plugin(self, playlist_manager, latest_refresh_info, current_dt):
         """Determines the next plugin to refresh by scanning all plugins in the active playlist.
 
-        Iterates every plugin starting from the one after the last refreshed index
-        (round-robin fairness) and returns the first plugin whose should_refresh()
-        returns True.  If no plugin is due, returns (None, None) so the display
-        is not updated.
+        Collects every plugin whose should_refresh() returns True, computes each
+        one's effective due datetime, and selects the plugin that has been overdue
+        the longest (oldest due time).  Ties are broken by playlist order starting
+        from the round-robin index for fairness.
+
+        If no plugin is due, returns (None, None) so the display is not updated.
         """
         playlist = playlist_manager.determine_active_playlist(current_dt)
         if not playlist:
@@ -188,27 +190,43 @@ class RefreshTask:
             logger.info(f"Active playlist '{playlist.name}' has no plugins.")
             return None, None
 
-        # Scan every plugin in the playlist, starting after the last-refreshed
-        # index so that no single plugin starves the others.
+        # Collect all due plugins with their effective due datetimes
         num_plugins = len(playlist.plugins)
         start_index = ((playlist.current_plugin_index or -1) + 1) % num_plugins
+        due_plugins = []
 
         for i in range(num_plugins):
             idx = (start_index + i) % num_plugins
             plugin = playlist.plugins[idx]
             if plugin.should_refresh(current_dt):
-                playlist.current_plugin_index = idx
-                logger.info(
-                    f"Plugin due for refresh. | active_playlist: {playlist.name} "
-                    f"| plugin_instance: {plugin.name} | index: {idx}"
+                due_dt = plugin.get_due_datetime(current_dt)
+                due_plugins.append((due_dt, i, idx, plugin))  # i = scan order for tie-breaking
+                logger.debug(
+                    f"Plugin due: {plugin.name} | due_datetime: {due_dt.strftime('%Y-%m-%d %H:%M:%S')} "
+                    f"| overdue_seconds: {(current_dt - due_dt).total_seconds():.0f}"
                 )
-                return playlist, plugin
 
+        if not due_plugins:
+            logger.info(
+                f"No plugins due for refresh in playlist '{playlist.name}'. "
+                f"| checked: {num_plugins} plugin(s)"
+            )
+            return None, None
+
+        # Select the plugin with the oldest due time (most overdue).
+        # Ties broken by scan order (round-robin fairness).
+        due_plugins.sort(key=lambda x: (x[0], x[1]))
+        selected_due_dt, _, selected_idx, selected_plugin = due_plugins[0]
+
+        playlist.current_plugin_index = selected_idx
         logger.info(
-            f"No plugins due for refresh in playlist '{playlist.name}'. "
-            f"| checked: {num_plugins} plugin(s)"
+            f"Selected plugin for refresh. | active_playlist: {playlist.name} "
+            f"| plugin_instance: {selected_plugin.name} | index: {selected_idx} "
+            f"| due_datetime: {selected_due_dt.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"| overdue_seconds: {(current_dt - selected_due_dt).total_seconds():.0f} "
+            f"| total_due_plugins: {len(due_plugins)}"
         )
-        return None, None
+        return playlist, selected_plugin
     
     def log_system_stats(self):
         metrics = {

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -170,11 +170,17 @@ class RefreshTask:
         return datetime.now(pytz.timezone(tz_str))
 
     def _determine_next_plugin(self, playlist_manager, latest_refresh_info, current_dt):
-        """Determines the next plugin to refresh based on the active playlist, plugin cycle interval, and current time."""
+        """Determines the next plugin to refresh by scanning all plugins in the active playlist.
+
+        Iterates every plugin starting from the one after the last refreshed index
+        (round-robin fairness) and returns the first plugin whose should_refresh()
+        returns True.  If no plugin is due, returns (None, None) so the display
+        is not updated.
+        """
         playlist = playlist_manager.determine_active_playlist(current_dt)
         if not playlist:
             playlist_manager.active_playlist = None
-            logger.info(f"No active playlist determined.")
+            logger.info("No active playlist determined.")
             return None, None
 
         playlist_manager.active_playlist = playlist.name
@@ -182,25 +188,27 @@ class RefreshTask:
             logger.info(f"Active playlist '{playlist.name}' has no plugins.")
             return None, None
 
-        latest_refresh_dt = latest_refresh_info.get_refresh_datetime()
-        plugin_cycle_interval = self.device_config.get_config("plugin_cycle_interval_seconds", default=3600)
-        should_refresh = PlaylistManager.should_refresh(latest_refresh_dt, plugin_cycle_interval, current_dt)
+        # Scan every plugin in the playlist, starting after the last-refreshed
+        # index so that no single plugin starves the others.
+        num_plugins = len(playlist.plugins)
+        start_index = ((playlist.current_plugin_index or -1) + 1) % num_plugins
 
-        if not should_refresh:
-            latest_refresh_str = latest_refresh_dt.strftime('%Y-%m-%d %H:%M:%S') if latest_refresh_dt else "None"
-            logger.info(f"Not time to update display. | latest_update: {latest_refresh_str} | plugin_cycle_interval: {plugin_cycle_interval}")
-            return None, None
+        for i in range(num_plugins):
+            idx = (start_index + i) % num_plugins
+            plugin = playlist.plugins[idx]
+            if plugin.should_refresh(current_dt):
+                playlist.current_plugin_index = idx
+                logger.info(
+                    f"Plugin due for refresh. | active_playlist: {playlist.name} "
+                    f"| plugin_instance: {plugin.name} | index: {idx}"
+                )
+                return playlist, plugin
 
-        # Select the next plugin in the playlist for display rotation. Whether its image
-        # needs to be regenerated vs using a cached image should be decided during
-        # the refresh execution phase, not here.
-        plugin = playlist.get_next_plugin()
-        if not plugin:
-            logger.info(f"Failed to obtain next plugin from playlist '{playlist.name}'.")
-            return None, None
-
-        logger.info(f"Determined next plugin. | active_playlist: {playlist.name} | plugin_instance: {plugin.name}")
-        return playlist, plugin
+        logger.info(
+            f"No plugins due for refresh in playlist '{playlist.name}'. "
+            f"| checked: {num_plugins} plugin(s)"
+        )
+        return None, None
     
     def log_system_stats(self):
         metrics = {

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -112,6 +112,12 @@ class RefreshTask:
                             continue
                         plugin = get_plugin_instance(plugin_config)
                         image = refresh_action.execute(plugin, self.device_config, current_dt)
+
+                        # If execute returns None, the plugin was skipped (not time to refresh)
+                        if image is None:
+                            self.device_config.write_config()
+                            continue
+
                         image_hash = compute_image_hash(image)
 
                         refresh_info = refresh_action.get_refresh_info()
@@ -280,9 +286,8 @@ class PlaylistRefresh(RefreshAction):
             image.save(plugin_image_path)
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
         else:
-            logger.info(f"Not time to refresh plugin instance, using latest image. | plugin_instance: {self.plugin_instance.name}.")
-            # Load the existing image from disk
-            with Image.open(plugin_image_path) as img:
-                image = img.copy()
+            logger.info(f"Not time to refresh plugin instance, skipping. | plugin_instance: {self.plugin_instance.name}.")
+            # Return None to signal that this plugin should be skipped
+            return None
 
         return image

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -103,7 +103,7 @@ class RefreshTask:
                         logger.info(f"Running interval refresh check. | current_time: {current_dt.strftime('%Y-%m-%d %H:%M:%S')}")
                         playlist, plugin_instance = self._determine_next_plugin(playlist_manager, latest_refresh, current_dt)
                         if plugin_instance:
-                            refresh_action = PlaylistRefresh(playlist, plugin_instance)
+                            refresh_action = PlaylistRefresh(playlist, plugin_instance, force=True)
 
                     if refresh_action:
                         plugin_config = self.device_config.get_plugin(refresh_action.get_plugin_id())
@@ -188,10 +188,18 @@ class RefreshTask:
             logger.info(f"Not time to update display. | latest_update: {latest_refresh_str} | plugin_cycle_interval: {plugin_cycle_interval}")
             return None, None
 
-        plugin = playlist.get_next_plugin()
-        logger.info(f"Determined next plugin. | active_playlist: {playlist.name} | plugin_instance: {plugin.name}")
+        # Loop through all plugins in the playlist to find one that needs refreshing
+        num_plugins = len(playlist.plugins)
+        for _ in range(num_plugins):
+            plugin = playlist.get_next_plugin()
+            if plugin.should_refresh(current_dt):
+                logger.info(f"Determined next plugin. | active_playlist: {playlist.name} | plugin_instance: {plugin.name}")
+                return playlist, plugin
+            else:
+                logger.info(f"Plugin '{plugin.name}' not due for refresh, skipping.")
 
-        return playlist, plugin
+        logger.info(f"No plugins in playlist '{playlist.name}' need refreshing.")
+        return None, None
     
     def log_system_stats(self):
         metrics = {

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -302,26 +302,14 @@ class PlaylistRefresh(RefreshAction):
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
             return image
 
-        # Not time to regenerate — load and return the cached image from disk to keep
-        # playlist rotation working. Return None only for error/skip conditions.
+        # Not time to regenerate — return None so the caller skips the display
+        # update.  The rotation index has already been advanced by
+        # get_next_plugin(), so the *next* cycle will evaluate the following
+        # plugin in the playlist.  This avoids unnecessary e-paper refreshes
+        # (which cause visible flashing) when no plugin has new content.
         logger.info(
-            f"Not time to refresh plugin instance; using cached image. | plugin_instance: {self.plugin_instance.name}."
+            f"Not time to refresh plugin instance; skipping display update. "
+            f"| plugin_instance: {self.plugin_instance.name} "
+            f"| latest_refresh: {self.plugin_instance.latest_refresh_time}"
         )
-
-        if not os.path.exists(plugin_image_path):
-            logger.error(
-                f"Cached image for plugin instance is missing; cannot display. | plugin_instance: {self.plugin_instance.name} | path: {plugin_image_path}"
-            )
-            return None
-
-        try:
-            image = Image.open(plugin_image_path)
-            # Ensure the image data is actually loaded before returning
-            image.load()
-            # Do not update plugin_instance.latest_refresh_time — we are using cached content.
-            return image
-        except Exception as exc:
-            logger.exception(
-                f"Failed to load cached image for plugin instance; skipping. | plugin_instance: {self.plugin_instance.name}, path: {plugin_image_path}"
-            )
-            return None
+        return None

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -115,6 +115,11 @@ class RefreshTask:
 
                         # If execute returns None, the plugin was skipped (not time to refresh)
                         if image is None:
+                            # Revert playlist index so this plugin is retried next cycle
+                            if isinstance(refresh_action, PlaylistRefresh):
+                                playlist = refresh_action.playlist
+                                if playlist.current_plugin_index is not None:
+                                    playlist.current_plugin_index = (playlist.current_plugin_index - 1) % len(playlist.plugins)
                             self.device_config.write_config()
                             continue
 

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -103,7 +103,10 @@ class RefreshTask:
                         logger.info(f"Running interval refresh check. | current_time: {current_dt.strftime('%Y-%m-%d %H:%M:%S')}")
                         playlist, plugin_instance = self._determine_next_plugin(playlist_manager, latest_refresh, current_dt)
                         if plugin_instance:
-                            refresh_action = PlaylistRefresh(playlist, plugin_instance, force=True)
+                            # Do not force regeneration here; let the PlaylistRefresh decide whether to
+                            # regenerate the plugin's image or load the cached image. This keeps
+                            # display rotation independent from image regeneration.
+                            refresh_action = PlaylistRefresh(playlist, plugin_instance, force=False)
 
                     if refresh_action:
                         plugin_config = self.device_config.get_plugin(refresh_action.get_plugin_id())
@@ -188,18 +191,16 @@ class RefreshTask:
             logger.info(f"Not time to update display. | latest_update: {latest_refresh_str} | plugin_cycle_interval: {plugin_cycle_interval}")
             return None, None
 
-        # Loop through all plugins in the playlist to find one that needs refreshing
-        num_plugins = len(playlist.plugins)
-        for _ in range(num_plugins):
-            plugin = playlist.get_next_plugin()
-            if plugin.should_refresh(current_dt):
-                logger.info(f"Determined next plugin. | active_playlist: {playlist.name} | plugin_instance: {plugin.name}")
-                return playlist, plugin
-            else:
-                logger.info(f"Plugin '{plugin.name}' not due for refresh, skipping.")
+        # Select the next plugin in the playlist for display rotation. Whether its image
+        # needs to be regenerated vs using a cached image should be decided during
+        # the refresh execution phase, not here.
+        plugin = playlist.get_next_plugin()
+        if not plugin:
+            logger.info(f"Failed to obtain next plugin from playlist '{playlist.name}'.")
+            return None, None
 
-        logger.info(f"No plugins in playlist '{playlist.name}' need refreshing.")
-        return None, None
+        logger.info(f"Determined next plugin. | active_playlist: {playlist.name} | plugin_instance: {plugin.name}")
+        return playlist, plugin
     
     def log_system_stats(self):
         metrics = {
@@ -299,9 +300,24 @@ class PlaylistRefresh(RefreshAction):
                 return None
             image.save(plugin_image_path)
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
-        else:
-            logger.info(f"Not time to refresh plugin instance, skipping. | plugin_instance: {self.plugin_instance.name}.")
-            # Return None to signal that this plugin should be skipped
-            return None
+            return image
 
+        # Not time to regenerate — attempt to load a cached image for display rotation.
+        logger.info(f"Using cached image for plugin instance if available. | plugin_instance: {self.plugin_instance.name}.")
+        if os.path.exists(plugin_image_path):
+            try:
+                image = Image.open(plugin_image_path)
+                # Do not update plugin_instance.latest_refresh_time — we are using cached content.
+                return image
+            except Exception:
+                logger.exception(f"Failed to load cached image for '{self.plugin_instance.name}', will attempt regeneration.")
+
+        # If cached image not present or failed to load, fall back to regenerating the image.
+        logger.info(f"Cached image missing or unreadable; regenerating. | plugin_instance: {self.plugin_instance.name}")
+        image = plugin.generate_image(self.plugin_instance.settings, device_config)
+        if image is None:
+            logger.error(f"Plugin '{self.plugin_instance.name}' returned no image on regeneration. Skipping.")
+            return None
+        image.save(plugin_image_path)
+        self.plugin_instance.latest_refresh_time = current_dt.isoformat()
         return image

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -115,11 +115,6 @@ class RefreshTask:
 
                         # If execute returns None, the plugin was skipped (not time to refresh)
                         if image is None:
-                            # Revert playlist index so this plugin is retried next cycle
-                            if isinstance(refresh_action, PlaylistRefresh):
-                                playlist = refresh_action.playlist
-                                if playlist.current_plugin_index is not None:
-                                    playlist.current_plugin_index = (playlist.current_plugin_index - 1) % len(playlist.plugins)
                             self.device_config.write_config()
                             continue
 
@@ -288,6 +283,9 @@ class PlaylistRefresh(RefreshAction):
             logger.info(f"Refreshing plugin instance. | plugin_instance: '{self.plugin_instance.name}'") 
             # Generate a new image
             image = plugin.generate_image(self.plugin_instance.settings, device_config)
+            if image is None:
+                logger.error(f"Plugin '{self.plugin_instance.name}' returned no image. Skipping.")
+                return None
             image.save(plugin_image_path)
             self.plugin_instance.latest_refresh_time = current_dt.isoformat()
         else:

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -245,7 +245,10 @@ class ManualRefresh(RefreshAction):
 
     def execute(self, plugin, device_config, current_dt: datetime):
         """Performs a manual refresh using the stored plugin ID and settings."""
-        return plugin.generate_image(self.plugin_settings, device_config)
+        image = plugin.generate_image(self.plugin_settings, device_config)
+        if image is None:
+            raise RuntimeError(f"Plugin '{self.plugin_id}' failed to generate an image.")
+        return image
 
     def get_refresh_info(self):
         """Return refresh metadata as a dictionary."""

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -130,7 +130,7 @@ class RefreshTask:
                             logger.info(f"Updating display. | refresh_info: {refresh_info}")
                             self.display_manager.display_image(image, image_settings=plugin.config.get("image_settings", []))
                         else:
-                            logger.info(f"Image already displayed, skipping refresh. | refresh_info: {refresh_info}")
+                            logger.debug(f"Image already displayed, skipping refresh. | refresh_info: {refresh_info}")
 
                         # update latest refresh data in the device config
                         self.device_config.refresh_info = RefreshInfo(**refresh_info)
@@ -303,7 +303,7 @@ class PlaylistRefresh(RefreshAction):
             return image
 
         # Not time to regenerate — attempt to load a cached image for display rotation.
-        logger.info(f"Using cached image for plugin instance if available. | plugin_instance: {self.plugin_instance.name}.")
+        logger.debug(f"Using cached image for plugin instance if available. | plugin_instance: {self.plugin_instance.name}.")
         if os.path.exists(plugin_image_path):
             try:
                 image = Image.open(plugin_image_path)
@@ -313,7 +313,7 @@ class PlaylistRefresh(RefreshAction):
                 logger.exception(f"Failed to load cached image for '{self.plugin_instance.name}', will attempt regeneration.")
 
         # If cached image not present or failed to load, fall back to regenerating the image.
-        logger.info(f"Cached image missing or unreadable; regenerating. | plugin_instance: {self.plugin_instance.name}")
+        logger.debug(f"Cached image missing or unreadable; regenerating. | plugin_instance: {self.plugin_instance.name}")
         image = plugin.generate_image(self.plugin_instance.settings, device_config)
         if image is None:
             logger.error(f"Plugin '{self.plugin_instance.name}' returned no image on regeneration. Skipping.")

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -51,6 +51,12 @@
             refreshImage();
             setInterval(refreshImage, refreshIntervalMs);
         });
+
+        window.addEventListener('pageshow', function(event) {
+            if (event.persisted) {
+                location.reload();
+            }
+        });
     </script>
     <script src="{{ url_for('static', filename='scripts/image_modal.js') }}"></script>
 </head>

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -75,7 +75,11 @@
 
         <!-- Display the current image -->
         <div class="image-container">
-            <img src="{{ url_for('static', filename='images/current_image.png') }}" alt="Current Image">
+            <img src="{{ url_for('static', filename='images/current_image.png') }}" alt="Current Image"
+                 onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+            <div style="display:none; width:100%; aspect-ratio:5/3; background:var(--bg-secondary, #f0f0f0); border-radius:8px; align-items:center; justify-content:center; color:var(--text-secondary, #888); font-size:14px;">
+                No image displayed yet
+            </div>
         </div>
 
         <!-- Separator -->

--- a/src/templates/inky.html
+++ b/src/templates/inky.html
@@ -82,7 +82,8 @@
         <!-- Display the current image -->
         <div class="image-container">
             <img src="{{ url_for('static', filename='images/current_image.png') }}" alt="Current Image"
-                 onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                 onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';"
+                 onload="this.style.display='block'; this.nextElementSibling.style.display='none';">
             <div style="display:none; width:100%; aspect-ratio:5/3; background:var(--bg-secondary, #f0f0f0); border-radius:8px; align-items:center; justify-content:center; color:var(--text-secondary, #888); font-size:14px;">
                 No image displayed yet
             </div>

--- a/tests/test_plugin_instance_refresh.py
+++ b/tests/test_plugin_instance_refresh.py
@@ -70,3 +70,21 @@ def test_scheduled_refresh_when_latest_refresh_varies():
     p = make_plugin(refresh={"scheduled": "08:00"}, latest_refresh_time=latest.isoformat())
     now = datetime(2022, 1, 2, 8, 0, 0)
     assert p.should_refresh(now) is True
+
+
+def test_never_refreshed_scheduled_with_tz_aware_current_time():
+    # when current_time is timezone-aware we should not raise and should compare correctly
+    p = make_plugin(refresh={"scheduled": "14:00"})
+    now = datetime(2022, 1, 2, 14, 0, 0, tzinfo=timezone.utc)
+    assert p.should_refresh(now) is True
+
+    now = datetime(2022, 1, 2, 13, 59, 0, tzinfo=timezone.utc)
+    assert p.should_refresh(now) is False
+
+
+def test_scheduled_refresh_timezone_aware_latest_and_current():
+    # both latest and current are timezone-aware
+    latest = datetime(2022, 1, 1, 23, 59, 0, tzinfo=timezone.utc)
+    p = make_plugin(refresh={"scheduled": "08:00"}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 8, 0, 0, tzinfo=timezone.utc)
+    assert p.should_refresh(now) is True

--- a/tests/test_plugin_instance_refresh.py
+++ b/tests/test_plugin_instance_refresh.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timezone
+
+from src.model import PluginInstance
+
+
+def make_plugin(refresh, latest_refresh_time=None):
+    return PluginInstance(plugin_id="p1", name="inst", settings={}, refresh=refresh, latest_refresh_time=latest_refresh_time)
+
+
+def test_never_refreshed_with_and_without_scheduled():
+    # no scheduled -> should refresh immediately
+    p = make_plugin(refresh={})
+    now = datetime(2022, 1, 2, 14, 0, 0)
+    assert p.should_refresh(now) is True
+
+    # scheduled in future -> should not refresh
+    p = make_plugin(refresh={"scheduled": "15:00"})
+    now = datetime(2022, 1, 2, 14, 0, 0)
+    assert p.should_refresh(now) is False
+
+    # scheduled at or before current time -> should refresh
+    p = make_plugin(refresh={"scheduled": "14:00"})
+    now = datetime(2022, 1, 2, 14, 0, 0)
+    assert p.should_refresh(now) is True
+
+
+def test_interval_refresh_naive_datetimes():
+    # latest refresh 2 minutes ago, interval 60s -> should refresh
+    latest = datetime(2022, 1, 2, 14, 0, 0)
+    p = make_plugin(refresh={"interval": 60}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 14, 2, 0)
+    assert p.should_refresh(now) is True
+
+    # latest refresh 30s ago, interval 120s -> should not refresh
+    latest = datetime(2022, 1, 2, 14, 1, 30)
+    p = make_plugin(refresh={"interval": 120}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 14, 2, 0)
+    assert p.should_refresh(now) is False
+
+
+def test_interval_refresh_timezone_aware_datetimes():
+    # use timezone-aware datetimes for both latest and current times
+    latest = datetime(2022, 1, 2, 14, 0, 0, tzinfo=timezone.utc)
+    p = make_plugin(refresh={"interval": 60}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 14, 2, 0, tzinfo=timezone.utc)
+    assert p.should_refresh(now) is True
+
+    # not yet reached interval
+    latest = datetime(2022, 1, 2, 14, 1, 30, tzinfo=timezone.utc)
+    p = make_plugin(refresh={"interval": 120}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 14, 2, 0, tzinfo=timezone.utc)
+    assert p.should_refresh(now) is False
+
+
+def test_scheduled_refresh_when_latest_refresh_varies():
+    # latest refresh earlier same day before scheduled -> should refresh when current is at scheduled
+    latest = datetime(2022, 1, 2, 14, 0, 0)
+    p = make_plugin(refresh={"scheduled": "15:00"}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 15, 0, 0)
+    assert p.should_refresh(now) is True
+
+    # latest refresh on same day after scheduled -> should not refresh
+    latest = datetime(2022, 1, 2, 15, 30, 0)
+    p = make_plugin(refresh={"scheduled": "15:00"}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 16, 0, 0)
+    assert p.should_refresh(now) is False
+
+    # latest refresh previous day -> should refresh at scheduled time today
+    latest = datetime(2022, 1, 1, 23, 59, 0)
+    p = make_plugin(refresh={"scheduled": "08:00"}, latest_refresh_time=latest.isoformat())
+    now = datetime(2022, 1, 2, 8, 0, 0)
+    assert p.should_refresh(now) is True


### PR DESCRIPTION
**Description**

This PR improves the refresh logic and fixes stability issues in InkyPi. Fixes #380

**Changes**

- Process all plugins in the active playlist each cycle
- Fix playlist iteration getting stuck on a single plugin
- Ensure scheduled and interval plugins refresh at the correct time
- Prevent crash when a plugin returns no image
- Add error handling and clearer logging for failed plugins
- Return clear error when plugin fails to generate image
- Add placeholder to avoid broken image on first load
- Auto-reload main page on browser back navigation

**Impact**

- More reliable and responsive refresh behavior
- No crashes when plugin image generation fails
- Clearer error visibility for plugin failures
- Better UX when navigating back in the browser
- Better handling of initial and error states

<img width="1074" height="879" alt="2026-03-19_17-15" src="https://github.com/user-attachments/assets/1b2a9f1d-e51c-4030-9da0-09865de4035c" />
<img width="1603" height="741" alt="2026-03-19_16-02" src="https://github.com/user-attachments/assets/67f2a009-05ed-4c81-91d3-a3a1d3f328d8" />
