### PR TITLE
feat(weather): allow manual latitude/longitude input

### DIFF
--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -117,6 +117,16 @@
 
 <script>
 
+    /** Return true when value is a non-empty string that parses to a finite number. */
+    function hasCoord(value) {
+        return typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value));
+    }
+
+    /** Parse a coordinate string, returning fallback when empty/invalid. */
+    function parseCoord(value, fallback) {
+        return hasCoord(value) ? Number(value) : fallback;
+    }
+
     function updateTitleOptions(provider) {
         const titleLocationRadio = document.getElementById('title-location');
         const titleLocationLabel = document.querySelector('label[for="title-location"]');
@@ -169,29 +179,36 @@
         const $mapModal = document.querySelector('#mapModal');
         const $closeMap = document.querySelector('#closeMap');
 
-        let latitude = Number($latitude.value) || 0;
-        let longitude = Number($longitude.value) || 0;
-        let zoom = $latitude.value && $longitude.value ? 4.5 : 2.5;
+        let latitude = parseCoord($latitude.value, 0);
+        let longitude = parseCoord($longitude.value, 0);
+        let zoom = hasCoord($latitude.value) && hasCoord($longitude.value) ? 4.5 : 2.5;
         let selectedTitle = 'location';
         let weatherProvider = 'OpenMeteo';
 
         let map, marker;
+        let markerMoved = false;
+        let hadValidCoords = false;
 
         $openMap.addEventListener('click', () => {
             // Re-read the current latitude/longitude inputs in case the user
             // edited them manually after the page loaded.
             const latInput = document.getElementById('latitude').value;
             const longInput = document.getElementById('longitude').value;
-            const parsedLat = Number(latInput);
-            const parsedLong = Number(longInput);
 
-            if (Number.isFinite(parsedLat) && Number.isFinite(parsedLong)) {
-                latitude = parsedLat;
-                longitude = parsedLong;
+            hadValidCoords = hasCoord(latInput) && hasCoord(longInput);
+            markerMoved = false;
+
+            if (hadValidCoords) {
+                const parsedLat = Number(latInput);
+                const parsedLong = Number(longInput);
+                if (Number.isFinite(parsedLat) && Number.isFinite(parsedLong)) {
+                    latitude = parsedLat;
+                    longitude = parsedLong;
+                }
             }
 
             // Recompute zoom based on whether coordinates are present
-            zoom = (document.getElementById('latitude').value && document.getElementById('longitude').value) ? 4.5 : 2.5;
+            zoom = hadValidCoords ? 4.5 : 2.5;
 
             openModal('mapModal');
             setTimeout(() => {
@@ -202,6 +219,10 @@
 
                     map.on('click', event => {
                         marker.setLatLng(event.latlng);
+                        markerMoved = true;
+                    });
+                    marker.on('dragend', () => {
+                        markerMoved = true;
                     });
                 } else {
                     map.invalidateSize();
@@ -212,9 +233,13 @@
         });
 
         $closeMap.addEventListener('click', () => {
-            const position = marker.getLatLng().wrap();
-            $latitude.value = position.lat;
-            $longitude.value = position.lng;
+            // Only persist coordinates if the user moved the marker
+            // or the inputs already had valid values before opening.
+            if (markerMoved || hadValidCoords) {
+                const position = marker.getLatLng().wrap();
+                $latitude.value = position.lat;
+                $longitude.value = position.lng;
+            }
             closeModal('mapModal');
         });
 
@@ -274,9 +299,9 @@
             document.getElementById('weatherTimeZone').value = "locationTimeZone";
         }
 
-        latitude = Number(document.getElementById('latitude').value) || 0;
-        longitude = Number(document.getElementById('longitude').value) || 0;
-        zoom = document.getElementById('latitude').value && document.getElementById('longitude').value ? 4.5 : 2.5;
+        latitude = parseCoord(document.getElementById('latitude').value, 0);
+        longitude = parseCoord(document.getElementById('longitude').value, 0);
+        zoom = hasCoord(document.getElementById('latitude').value) && hasCoord(document.getElementById('longitude').value) ? 4.5 : 2.5;
 
         document.getElementById('weatherProvider').value = weatherProvider;
         document.querySelector(`input[name="titleSelection"][value="${selectedTitle}"]`).checked = true;

--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -244,8 +244,8 @@
         });
 
         if (loadPluginSettings) {
-            document.getElementById('latitude').value = pluginSettings.latitude || '';
-            document.getElementById('longitude').value = pluginSettings.longitude || '';
+            document.getElementById('latitude').value = pluginSettings.latitude ?? '';
+            document.getElementById('longitude').value = pluginSettings.longitude ?? '';
 
             document.getElementById('units').value = pluginSettings.units;
 

--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -127,6 +127,40 @@
         return hasCoord(value) ? Number(value) : fallback;
     }
 
+    /** Validate lat/long inputs. Returns true if valid or both empty. */
+    function validateCoordInputs() {
+        const latVal = document.getElementById('latitude').value.trim();
+        const longVal = document.getElementById('longitude').value.trim();
+
+        // Both empty is fine (no location set yet)
+        if (latVal === '' && longVal === '') {
+            return true;
+        }
+
+        if (latVal === '' || longVal === '') {
+            showResponseModal('failure', 'Error! Both latitude and longitude are required.');
+            return false;
+        }
+
+        if (!hasCoord(latVal) || !hasCoord(longVal)) {
+            showResponseModal('failure', 'Error! Latitude and longitude must be valid numbers.');
+            return false;
+        }
+
+        const lat = Number(latVal);
+        const long = Number(longVal);
+        if (lat < -90 || lat > 90) {
+            showResponseModal('failure', 'Error! Latitude must be between -90 and 90.');
+            return false;
+        }
+        if (long < -180 || long > 180) {
+            showResponseModal('failure', 'Error! Longitude must be between -180 and 180.');
+            return false;
+        }
+
+        return true;
+    }
+
     function updateTitleOptions(provider) {
         const titleLocationRadio = document.getElementById('title-location');
         const titleLocationLabel = document.querySelector('label[for="title-location"]');
@@ -189,7 +223,11 @@
         let markerMoved = false;
         let hadValidCoords = false;
 
+        // Register global validation hook so handleAction can call it
+        window.pluginValidate = validateCoordInputs;
+
         $openMap.addEventListener('click', () => {
+            if (!validateCoordInputs()) return;
             // Re-read the current latitude/longitude inputs in case the user
             // edited them manually after the page loaded.
             const latInput = document.getElementById('latitude').value;

--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -5,11 +5,11 @@
     <label class="form-label">Location: </label>
     <div class="form-group">
         <span>Latitude </span>
-        <input readonly type="text" id="latitude" name="latitude" class="form-input" />
+        <input type="text" id="latitude" name="latitude" class="form-input" />
     </div>
     <div class="form-group">
         <span>Longitude </span>
-        <input readonly type="text" id="longitude" name="longitude" class="form-input" />
+        <input type="text" id="longitude" name="longitude" class="form-input" />
     </div>
     <button type="button" id="openMap" class="action-button compact">Select Location</button>
 </div>
@@ -169,16 +169,31 @@
         const $mapModal = document.querySelector('#mapModal');
         const $closeMap = document.querySelector('#closeMap');
 
-        let latitude = +$latitude.value;
-        let longitude = +$longitude.value;
-        let zoom = latitude && longitude ? 4.5 : 2.5;
+        let latitude = Number($latitude.value) || 0;
+        let longitude = Number($longitude.value) || 0;
+        let zoom = $latitude.value && $longitude.value ? 4.5 : 2.5;
         let selectedTitle = 'location';
         let weatherProvider = 'OpenMeteo';
 
         let map, marker;
 
         $openMap.addEventListener('click', () => {
-            openModal('mapModal')
+            // Re-read the current latitude/longitude inputs in case the user
+            // edited them manually after the page loaded.
+            const latInput = document.getElementById('latitude').value;
+            const longInput = document.getElementById('longitude').value;
+            const parsedLat = Number(latInput);
+            const parsedLong = Number(longInput);
+
+            if (Number.isFinite(parsedLat) && Number.isFinite(parsedLong)) {
+                latitude = parsedLat;
+                longitude = parsedLong;
+            }
+
+            // Recompute zoom based on whether coordinates are present
+            zoom = (document.getElementById('latitude').value && document.getElementById('longitude').value) ? 4.5 : 2.5;
+
+            openModal('mapModal');
             setTimeout(() => {
                 if (!map) {
                     map = L.map('map').setView([latitude, longitude], zoom);
@@ -188,6 +203,10 @@
                     map.on('click', event => {
                         marker.setLatLng(event.latlng);
                     });
+                } else {
+                    map.invalidateSize();
+                    map.setView([latitude, longitude], zoom);
+                    marker.setLatLng([latitude, longitude]);
                 }
             }, 100);
         });
@@ -200,8 +219,8 @@
         });
 
         if (loadPluginSettings) {
-            document.getElementById('latitude').value = pluginSettings.latitude;
-            document.getElementById('longitude').value = pluginSettings.longitude;
+            document.getElementById('latitude').value = pluginSettings.latitude || '';
+            document.getElementById('longitude').value = pluginSettings.longitude || '';
 
             document.getElementById('units').value = pluginSettings.units;
 
@@ -254,6 +273,10 @@
 			document.getElementById('moonPhase').value = "false";
             document.getElementById('weatherTimeZone').value = "locationTimeZone";
         }
+
+        latitude = Number(document.getElementById('latitude').value) || 0;
+        longitude = Number(document.getElementById('longitude').value) || 0;
+        zoom = document.getElementById('latitude').value && document.getElementById('longitude').value ? 4.5 : 2.5;
 
         document.getElementById('weatherProvider').value = weatherProvider;
         document.querySelector(`input[name="titleSelection"][value="${selectedTitle}"]`).checked = true;

--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -169,6 +169,14 @@
         return weatherHandleAction(action);
     };
 
+    const weatherOpenModal = window.openModal;
+    window.openModal = function(modalId) {
+        if (modalId === 'scheduleModal' && !validateCoordInputs()) {
+            return;
+        }
+        return weatherOpenModal(modalId);
+    };
+
     function updateTitleOptions(provider) {
         const titleLocationRadio = document.getElementById('title-location');
         const titleLocationLabel = document.querySelector('label[for="title-location"]');

--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -161,6 +161,14 @@
         return true;
     }
 
+    const weatherHandleAction = window.handleAction;
+    window.handleAction = async function(action) {
+        if (!validateCoordInputs()) {
+            return;
+        }
+        return weatherHandleAction(action);
+    };
+
     function updateTitleOptions(provider) {
         const titleLocationRadio = document.getElementById('title-location');
         const titleLocationLabel = document.querySelector('label[for="title-location"]');
@@ -222,9 +230,6 @@
         let map, marker;
         let markerMoved = false;
         let hadValidCoords = false;
-
-        // Register global validation hook so handleAction can call it
-        window.pluginValidate = validateCoordInputs;
 
         $openMap.addEventListener('click', () => {
             if (!validateCoordInputs()) return;

--- a/src/plugins/weather/weather.py
+++ b/src/plugins/weather/weather.py
@@ -72,10 +72,15 @@ class Weather(BasePlugin):
         return template_params
 
     def generate_image(self, settings, device_config):
-        lat = float(settings.get('latitude'))
-        long = float(settings.get('longitude'))
-        if not lat or not long:
+        raw_lat = settings.get('latitude', '').strip()
+        raw_long = settings.get('longitude', '').strip()
+        if not raw_lat or not raw_long:
             raise RuntimeError("Latitude and Longitude are required.")
+        try:
+            lat = float(raw_lat)
+            long = float(raw_long)
+        except (ValueError, TypeError):
+            raise RuntimeError("Latitude and Longitude must be valid numbers.")
 
         units = settings.get('units')
         if not units or units not in ['metric', 'imperial', 'standard']:


### PR DESCRIPTION
**Description**

This PR improves the Weather plugin by allowing users to manually input latitude and longitude, instead of relying only on the map picker.

This change was inspired by the feature request discussed here: [https://github.com/fatihak/InkyPi/discussions/564](https://github.com/fatihak/InkyPi/discussions/564)

**What was done**

* Allow direct input of latitude and longitude
* Remove readonly restriction from coordinate fields
* Sync manually entered coordinates when opening the map modal (validated with Number.isFinite)
* Reinitialize map view and marker when reopening with updated coordinates
* Adjust zoom level dynamically based on coordinate presence. Prevents incorrect zoom when users add or remove coordinates after page load. Ensures the map view always matches the current state of the inputs

**Why this matters**

* Fixes cases where Select Location may not work or appear blank
* Improves usability by allowing quick manual input
* Provides a fallback option without breaking existing behavior

**Additional Notes**

* No breaking changes
* Existing map selection flow remains unchanged
* Manual input supports validation and proper error handling for invalid values
* Invalid inputs (non-numeric values) are safely handled and return clear error messages without breaking the flow

**Screenshots**

- Map picker automatically synced with manually entered coordinates
- Successful update after entering coordinates directly in the input fields

<img width="2558" height="1359" alt="2026-03-28_12-29_2" src="https://github.com/user-attachments/assets/dabd49a8-b990-492b-b062-9dde27e23d4c" />
<img width="2558" height="1348" alt="2026-03-28_12-29_3" src="https://github.com/user-attachments/assets/917d07b5-3d12-4a84-ba31-b58a920ad287" />
