### PR TITLE
feat(year_progress): add language selection for localized labels

### DIFF
--- a/src/plugins/year_progress/render/year_progress.html
+++ b/src/plugins/year_progress/render/year_progress.html
@@ -5,14 +5,14 @@
 <div class="progress-container">
     <div class="progress-wrapper">
         <div class="progress-title">{{year}}</div>
-        <div class="progress-subtitle">PROGRESS</div>
+        <div class="progress-subtitle">{{label_progress}}</div>
         <div class="progress-bar">
             <div class="progress-fill" style="width: {{ year_percent }}%; background-color: {{plugin_settings.textColor}};"></div>
             <div class="progress-remaining" style="background-image: radial-gradient({{plugin_settings.textColor}} 1px, transparent 1px);"></div>
         </div>
         <div class="progress-labels">
-            <span>{{year_percent}}% DONE</span>
-            <span>{{days_left}} DAYS LEFT</span>
+            <span>{{year_percent}}% {{label_done}}</span>
+            <span>{{days_left}} {{label_days_left}}</span>
         </div>
     </div>
 </div>

--- a/src/plugins/year_progress/settings.html
+++ b/src/plugins/year_progress/settings.html
@@ -15,13 +15,20 @@
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         const language = document.getElementById('language');
-        if (typeof pluginSettings === 'object' && pluginSettings !== null) {
-            language.value = pluginSettings.language || 'en';
-            if (!language.querySelector(`option[value="${pluginSettings.language}"]`)) {
-                language.value = 'en';
-            }
-        } else {
-            language.value = 'en';
+        let selectedLanguage = 'en';
+
+        if (typeof pluginSettings === 'object' && pluginSettings !== null && typeof pluginSettings.language === 'string') {
+            selectedLanguage = pluginSettings.language;
         }
+
+        let hasOption = false;
+        for (let i = 0; i < language.options.length; i++) {
+            if (language.options[i].value === selectedLanguage) {
+                hasOption = true;
+                break;
+            }
+        }
+
+        language.value = hasOption ? selectedLanguage : 'en';
     });
 </script>

--- a/src/plugins/year_progress/settings.html
+++ b/src/plugins/year_progress/settings.html
@@ -1,0 +1,27 @@
+<div class="form-group">
+    <label for="language" class="form-label">Language:</label>
+    <select id="language" name="language" class="form-input">
+        <option value="nl">Dutch</option>
+        <option value="en">English</option>
+        <option value="fr">French</option>
+        <option value="de">German</option>
+        <option value="id">Indonesian</option>
+        <option value="it">Italian</option>
+        <option value="pt">Portuguese</option>
+        <option value="es">Spanish</option>
+    </select>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const language = document.getElementById('language');
+        if (typeof pluginSettings === 'object' && pluginSettings !== null) {
+            language.value = pluginSettings.language || 'en';
+            if (!language.querySelector(`option[value="${pluginSettings.language}"]`)) {
+                language.value = 'en';
+            }
+        } else {
+            language.value = 'en';
+        }
+    });
+</script>

--- a/src/plugins/year_progress/year_progress.py
+++ b/src/plugins/year_progress/year_progress.py
@@ -5,6 +5,17 @@ import logging
 import pytz
 
 logger = logging.getLogger(__name__)
+
+LOCALE_DATA = {
+    "de": {"done": "FERTIG", "progress": "FORTSCHRITT", "days_left": "TAGE ÜBRIG"},
+    "en": {"done": "DONE", "progress": "PROGRESS", "days_left": "DAYS LEFT"},
+    "es": {"done": "HECHO", "progress": "PROGRESO", "days_left": "DÍAS RESTANTES"},
+    "fr": {"done": "TERMINÉ", "progress": "PROGRESSION", "days_left": "JOURS RESTANTS"},
+    "id": {"done": "SELESAI", "progress": "KEMAJUAN", "days_left": "HARI TERSISA"},
+    "it": {"done": "FATTO", "progress": "PROGRESSO", "days_left": "GIORNI RIMASTI"},
+    "nl": {"done": "KLAAR", "progress": "VOORTGANG", "days_left": "DAGEN OVER"},
+    "pt": {"done": "CONCLUÍDO", "progress": "PROGRESSO", "days_left": "DIAS RESTANTES"},
+}
 class YearProgress(BasePlugin):
     def generate_settings_template(self):
         template_params = super().generate_settings_template()
@@ -27,11 +38,17 @@ class YearProgress(BasePlugin):
         days_left = (start_of_next_year - current_time).total_seconds() / (24 * 3600)
         elapsed_days = (current_time - start_of_year).total_seconds() / (24 * 3600)
 
+        language = str(settings.get("language", "en")).strip() or "en"
+        labels = LOCALE_DATA.get(language, LOCALE_DATA["en"])
+
         template_params = {
             "year": current_time.year,
             "year_percent": round((elapsed_days / total_days) * 100),
             "days_left": round(days_left),
-            "plugin_settings": settings
+            "plugin_settings": settings,
+            "label_done": labels["done"],
+            "label_progress": labels["progress"],
+            "label_days_left": labels["days_left"],
         }
         
         image = self.render_image(dimensions, "year_progress.html", "year_progress.css", template_params)

--- a/src/plugins/year_progress/year_progress.py
+++ b/src/plugins/year_progress/year_progress.py
@@ -38,7 +38,7 @@ class YearProgress(BasePlugin):
         days_left = (start_of_next_year - current_time).total_seconds() / (24 * 3600)
         elapsed_days = (current_time - start_of_year).total_seconds() / (24 * 3600)
 
-        language = str(settings.get("language", "en")).strip() or "en"
+        language = str(settings.get("language", "en")).strip().lower() or "en"
         labels = LOCALE_DATA.get(language, LOCALE_DATA["en"])
 
         template_params = {


### PR DESCRIPTION
## Summary

Add language selection to the Year Progress plugin so the three UI labels are localized directly inside the plugin

This change keeps the implementation simple and self contained, with no external API, no extra dependency, and no remote translation source

## What changed

* Added a new Language setting in the plugin configuration
* Added hardcoded locale labels for:

  * Dutch
  * English
  * French
  * German
  * Indonesian
  * Italian
  * Portuguese
  * Spanish
* Localized only the static UI labels used by the plugin:

  * Progress
  * Done
  * Days left
* Kept the rest of the plugin behavior unchanged

## Why hardcoded

This plugin only needs a very small and stable set of short labels, so hardcoding the translations keeps it:

* simple
* fast
* easy to maintain
* fully offline
* free from external service dependency

## Why these languages

I selected a compact set of widely used languages that makes sense for an open source project with an international audience, while keeping the settings list small and practical

The goal here was to cover common languages used by many users in community projects without overcomplicating the plugin

## Notes

* No external API was added
* No translation package was added
* No dynamic locale detection was added
* Only the three static labels were localized

## Screenshots

Configuration screen with the new language selector

Main screen example using Portuguese labels

<img width="2549" height="1366" alt="2026-03-28_13-48_1" src="https://github.com/user-attachments/assets/4a43c67a-8dc4-4142-86f7-c80ea3b96fbb" />

<img width="2558" height="1337" alt="2026-03-28_13-48" src="https://github.com/user-attachments/assets/ec1693a9-21b8-4549-a6a5-d2b2cbb3a7e1" />

