### PR TITLE
Fix plugin uninstall command and CLI help inconsistency

### DIFF
--- a/install/cli/inkypi-plugin
+++ b/install/cli/inkypi-plugin
@@ -10,7 +10,7 @@ usage() {
     echo ""
     echo "Plugin commands:"
     echo "  inkypi plugin install <plugin_id> <git_repository_url>"
-    echo "  inkypi plugin remove <plugin_id>"
+    echo "  inkypi plugin uninstall <plugin_id>"
     echo "  inkypi plugin list"
     echo ""
 }
@@ -95,7 +95,7 @@ install_plugin() {
 }
 
 # ----------------------------
-# REMOVE
+# UNINSTALL
 # ----------------------------
 uninstall_plugin() {
     if [[ $# -ne 1 ]]; then


### PR DESCRIPTION
This PR fixes an inconsistency between the CLI and the documentation for plugin removal

**Currently:**

* The CLI help shows inkypi plugin remove <plugin_id>
* The wiki documents inkypi plugin uninstall <plugin_id>
* The router already supports uninstall, but the usage text and comments still reference remove

**Changes:**

* Update CLI usage text from remove to uninstall
* Update comments from REMOVE to UNINSTALL
* Align CLI with documented command

**Result:**

* CLI help now correctly reflects the actual supported command
* Consistency between CLI and documentation

Testing:

* Verified that inkypi plugin shows uninstall in help
* Successfully installed and uninstalled a plugin using:
  inkypi plugin install mini_weather <repo_url>
  inkypi plugin uninstall mini_weather

<img width="1215" height="333" alt="2026-03-29_22-38" src="https://github.com/user-attachments/assets/ca39908d-06a6-4748-8c6a-d8849e7aefeb" />
