### PR TITLE
Added option to adjust  number of days displayed in calendar

### DIFF
--- a/src/plugins/calendar/calendar.py
+++ b/src/plugins/calendar/calendar.py
@@ -51,13 +51,16 @@ class Calendar(BasePlugin):
         if not events:
             logger.warning("No events found for ics url")
 
-        if view == 'timeGridWeek' and settings.get("displayPreviousDays") != "true":
+        initial_date = None
+        if view == 'timeGridWeek':
             view = 'timeGrid'
+            initial_date = start.strftime("%Y-%m-%d")
 
         template_params = {
             "view": view,
             "events": events,
             "current_dt": current_dt.replace(minute=0, second=0, microsecond=0).isoformat(),
+            "initial_date": initial_date,
             "timezone": timezone,
             "plugin_settings": settings,
             "time_format": time_format,
@@ -105,7 +108,7 @@ class Calendar(BasePlugin):
                 offset = (current_dt.weekday() - python_week_start) % 7
                 start = current_dt - timedelta(days=offset)
                 start = datetime(start.year, start.month, start.day)
-            end = start + timedelta(days=7)
+            end = start + timedelta(days=int(settings.get("numDays") or 7))
         elif view == "dayGrid":
             start = current_dt - timedelta(weeks=1)
             end = current_dt + timedelta(weeks=int(settings.get("displayWeeks") or 4))

--- a/src/plugins/calendar/render/calendar.html
+++ b/src/plugins/calendar/render/calendar.html
@@ -33,6 +33,7 @@
 
         const calendar = new FullCalendar.Calendar(calendarEl, {
             initialView: '{{ view }}',
+            {% if initial_date %}initialDate: '{{ initial_date }}',{% endif %}
             events: events,
             now: '{{ current_dt }}',
             timeZone: '{{ timezone }}',
@@ -49,7 +50,7 @@
             weekends:  {{ (plugin_settings.displayWeekends == "true") | tojson}},
             nowIndicator: {{ (plugin_settings.displayNowIndicator == "true") | tojson}},
             fixedWeekCount: false,
-            {% if view == 'timeGrid' %}duration: {days : 7 },{% endif %}
+            {% if view == 'timeGrid' %}duration: {days : {{ plugin_settings.numDays | default(7) | int }} },{% endif %}
             {% if view == 'dayGrid' %}duration: {weeks : "{{ plugin_settings.displayWeeks or 4}}" },{% endif %}
             headerToolbar: {
                 left: '',

--- a/src/plugins/calendar/settings.html
+++ b/src/plugins/calendar/settings.html
@@ -77,6 +77,11 @@
         <input type="number" id="endTimeInterval" name="endTimeInterval" class="form-input" min="0" max="24" placeholder="24">
     </div>
 
+    <div class="form-group nowrap" data-visible-modes="timeGridWeek">
+        <label for="numDays">Number of Days:</label>
+        <input type="number" id="numDays" name="numDays" class="form-input" min="1" max="30" placeholder="7" value="7">
+    </div>
+
     <div class="form-group nowrap" data-visible-modes="dayGrid">
         <label for="interval">Display Weeks:</label>
         <input type="number" id="displayWeeks" name="displayWeeks" class="form-input" min="1" max="52" placeholder="4">
@@ -201,6 +206,8 @@
             document.getElementById("endTimeInterval").value = pluginSettings.endTimeInterval;
 
             document.getElementById("displayWeeks").value = pluginSettings.displayWeeks;
+
+            document.getElementById("numDays").value = pluginSettings.numDays || 7;
             
             if (pluginSettings["calendarURLs[]"]) {
                 calendars = pluginSettings["calendarURLs[]"].map((url, i) => ({


### PR DESCRIPTION
This PR adds an option to adjust the number of days displayed by the calendar. 

On many e-ink displays, trying to display 7 days can make the individual columns to narrow.
Now, when using the week-layout, the user can set the number to display.

I had already created a similar PR back in August, but forgot the ability to save the selected number of days. This PR fixes that.