### PR TITLE
Fix Immich API to retrieve assets from album

### DIFF
--- a/src/plugins/image_album/image_album.py
+++ b/src/plugins/image_album/image_album.py
@@ -31,27 +31,17 @@ class ImmichProvider:
 
     def get_assets(self, album_id: str) -> list[dict]:
         """Fetch all assets from album."""
-        all_items = []
-        page_items = [1]
-        page = 1
-
         logger.debug(f"Fetching assets from album {album_id}")
-        while page_items:
-            body = {
-                "albumIds": [album_id],
-                "size": 1000,
-                "page": page
-            }
-            r2 = self.session.post(f"{self.base_url}/api/search/metadata", json=body, headers=self.headers)
-            r2.raise_for_status()
-            assets_data = r2.json()
-
-            page_items = assets_data.get("assets", {}).get("items", [])
-            all_items.extend(page_items)
-            page += 1
-
-        logger.debug(f"Found {len(all_items)} total assets in album")
-        return all_items
+        url = f"{self.base_url}/api/albums/{album_id}"
+        r = self.session.get(url, headers=self.headers)
+        r.raise_for_status()
+    
+        album_data = r.json()
+    
+        assets = album_data.get("assets", [])
+        logger.info(f"Found {len(assets)} total assets in album")
+    
+        return assets
 
     def get_image(self, album: str, dimensions: tuple[int, int], resize: bool = True) -> Image.Image | None:
         """


### PR DESCRIPTION
This PR fixes how the **image_album** plugin retrieves assets from Immich.

Previously, the plugin used a POST request to the search endpoint:
/api/search/metadata
This approach was unreliable and sometimes returned a subset of the images within an album.

The updated implementation replaces this with a GET request to:
/api/albums/{album_id}
This endpoint reliably returns all images contained in the album and removes the need for paginated requests.