### PR TITLE
Weather plugin: add sunshine and wind km/h over time display

### DIFF
--- a/src/plugins/weather/render/weather.html
+++ b/src/plugins/weather/render/weather.html
@@ -93,7 +93,9 @@
     const temperatures = [{% for hour in hourly_forecast %}{{ hour.temperature }}{% if not loop.last %}, {% endif %}{% endfor %}];
     const precipitation = [{% for hour in hourly_forecast %}{{ hour.precipitation * 100}}{% if not loop.last %}, {% endif %}{% endfor %}]; // Convert to percentage
     const rain = [{% for hour in hourly_forecast %}{{ hour.rain or 0 }}{% if not loop.last %}, {% endif %}{% endfor %}];
-    const weatherIconsPaths = [{% for hour in hourly_forecast %}"{{ hour.icon | replace('\\', '/') }}"{% if not loop.last %}, {% endif %}{% endfor %}];
+    const wind = [{% for hour in hourly_forecast %}{{ hour.wind or 0 }}{% if not loop.last %}, {% endif %}{% endfor %}];
+    const sunshine = [{% for hour in hourly_forecast %}{{ (hour.sunshine or 0) * 100 }}{% if not loop.last %}, {% endif %}{% endfor %}];
+	const weatherIconsPaths = [{% for hour in hourly_forecast %}"{{ hour.icon | replace('\\', '/') }}"{% if not loop.last %}, {% endif %}{% endfor %}];
 	const iconStep = parseInt("{{ plugin_settings.graphIconStep or 2 }}");
 	const units = document.getElementById('units-container').dataset.units;
 	const isImperial = units === "imperial";
@@ -140,6 +142,34 @@
         ctx.restore();
       }
     });
+Chart.register({
+  id: 'annotationWind',
+  afterDatasetsDraw(chart, args, pluginOptions) {
+    const windData = pluginOptions.windData || [];
+    if (!windData.length) return;
+    const { ctx, chartArea: { top, bottom }, scales: { x } } = chart;
+    const height = bottom - top;
+    const maxWind = Math.max(...windData, 50);
+    ctx.save();
+    ctx.strokeStyle = "{{ plugin_settings.textColor }}";
+    ctx.lineWidth = 2;
+    ctx.setLineDash([3, 2]);
+    ctx.beginPath();
+    windData.forEach((speed, i) => {
+      const xPos = x.getPixelForValue(i);
+      const yPos = bottom - (speed / maxWind) * height;
+      i === 0 ? ctx.moveTo(xPos, yPos) : ctx.lineTo(xPos, yPos);
+    });
+    ctx.stroke();
+    const lastVal = windData[windData.length - 1];
+    const lastX = x.getPixelForValue(windData.length - 1);
+    const lastY = bottom - (lastVal / maxWind) * height * 0.35;
+    ctx.fillStyle = "{{ plugin_settings.textColor }}";
+    ctx.font = '9px sans-serif';
+    ctx.fillText(lastVal.toFixed(1), lastX - 10, lastY - 4);
+    ctx.restore();
+  }
+});
 	
     {% if plugin_settings.displayGraphIcons == "true" %}
     Chart.register({
@@ -180,7 +210,8 @@
           borderColor: 'rgba(241, 122, 36, 0.9)', // Line color
           borderWidth: 2,
           pointRadius: 0, // Hide points
-          fill: true, // Enable filling the area under the line
+          // fill: true, // Enable filling the area under the line
+          fill: false, // Disable filling the area under the line
           tension: 0.5
         },
         {
@@ -194,11 +225,32 @@
             bottom: 0,
             left: 0
           },
+	  order: 1,
           yAxisID: 'y1',
           barPercentage: 1.0, // Ensures full width
           categoryPercentage: 1.0,  // Ensures full width
           fill: true, // Enable filling the area under the line
-        }
+        },
+	{% if plugin_settings.displaySunshine == "true" %}
+	{
+	  type: 'bar',
+	  label: 'Sunshine Probability',
+  	  data: sunshine,
+  	  borderColor: 'rgba(252, 204, 5, 1)',
+  	  borderWidth: {
+    	    top: 2,
+            right: 0,
+            bottom: 0,
+            left: 0
+  	  },
+  	  backgroundColor: 'rgba(252, 204, 5, 0.20)',
+	  order: 2,
+  	  yAxisID: 'y1',
+  	  barPercentage: 1.0,
+  	  categoryPercentage: 1.0,
+  	  fill: true,
+	},
+	{% endif %}
       ]
       },
       options: {
@@ -273,9 +325,12 @@
           }
         },
         plugins: {
-          legend: { display: false },
+          legend: { display: false }
 		  {% if plugin_settings.displayRain == "true" %}
-			annotationRain: { precipitationData: rain }
+			,annotationRain: { precipitationData: rain }
+	      {% endif %}
+	          {% if plugin_settings.displayWind == "true" %}
+		        ,annotationWind: { windData: wind }
 	      {% endif %}
         },
         elements: {
@@ -293,12 +348,12 @@
     const gradientEnd = chart.scales['y'].getPixelForValue(minTemp);   // Min temperature
 
     // Create gradient based on y-axis values
-    const tempGradient = ctx.createLinearGradient(0, gradientStart, 0, gradientEnd+10);
-    tempGradient.addColorStop(0, 'rgba(252,204,5, 0.95)'); // Top of the gradient (max temperature)
-    tempGradient.addColorStop(1, 'rgba(252,204,5, 0.01)'); // Bottom of the gradient (min temperature)
+    //const tempGradient = ctx.createLinearGradient(0, gradientStart, 0, gradientEnd+10);
+    //tempGradient.addColorStop(0, 'rgba(252,204,5, 0.95)'); // Top of the gradient (max temperature)
+    //tempGradient.addColorStop(1, 'rgba(252,204,5, 0.01)'); // Bottom of the gradient (min temperature)
 
     // Update the chart to apply the gradient
-    chart.data.datasets[0].backgroundColor = tempGradient;
+    //chart.data.datasets[0].backgroundColor = tempGradient;
 
     // Create gradient based on y-axis values
     const precipitationGradient = ctx.createLinearGradient(0, gradientStart, 0, gradientEnd);
@@ -306,6 +361,13 @@
     precipitationGradient.addColorStop(1, 'rgba(194, 223, 246, 0)'); // Bottom of the gradient (min temperature)
 
     chart.data.datasets[1].backgroundColor = precipitationGradient;
+
+    {% if plugin_settings.displaySunshine == "true" %}
+    const sunshineGradient = ctx.createLinearGradient(0, gradientStart, 0, gradientEnd);
+    sunshineGradient.addColorStop(0, 'rgba(252, 204, 5, 0.5)');
+    sunshineGradient.addColorStop(1, 'rgba(252, 204, 5, 0.0)');
+    chart.data.datasets[2].backgroundColor = sunshineGradient;
+    {% endif %}
 
     chart.update();
   });

--- a/src/plugins/weather/render/weather.html
+++ b/src/plugins/weather/render/weather.html
@@ -163,7 +163,7 @@ Chart.register({
     ctx.stroke();
     const lastVal = windData[windData.length - 1];
     const lastX = x.getPixelForValue(windData.length - 1);
-    const lastY = bottom - (lastVal / maxWind) * height * 0.35;
+    const lastY = Math.max(top + 10, bottom - (lastVal / maxWind) * height);
     ctx.fillStyle = "{{ plugin_settings.textColor }}";
     ctx.font = '9px sans-serif';
     ctx.fillText(lastVal.toFixed(1), lastX - 10, lastY - 4);
@@ -234,7 +234,7 @@ Chart.register({
 	{% if plugin_settings.displaySunshine == "true" %}
 	{
 	  type: 'bar',
-	  label: 'Sunshine Probability',
+	  label: 'Sunshine Duration',
   	  data: sunshine,
   	  borderColor: 'rgba(252, 204, 5, 1)',
   	  borderWidth: {

--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -64,7 +64,16 @@
         <input type="checkbox" id="displayRain" name="displayRain" onclick="this.value=this.checked ? 'true' : 'false';">
         <span>Rain Amount</span>
     </div>
-	
+
+    <div class="form-group">
+    	<input type="checkbox" id="displayWind" name="displayWind" value="false" onclick="this.value=this.checked ? 'true' : 'false';">
+    	<span>Wind Speed</span>
+    </div>
+
+    <div class="form-group">
+    	<input type="checkbox" id="displaySunshine" name="displaySunshine" value="false" onclick="this.value=this.checked ? 'true' : 'false';">
+    	<span>Sunshine</span>
+    </div>
 
     <div class="form-group">
         <input type="checkbox" id="moonPhase" name="moonPhase" onclick="this.value=this.checked ? 'true' : 'false';">
@@ -214,10 +223,16 @@
             document.getElementById('displayGraph').checked = pluginSettings.displayGraph;
             document.getElementById('displayGraph').value = pluginSettings.displayGraph;
 
-			document.getElementById('displayRain').checked = pluginSettings.displayRain;
+	    document.getElementById('displayRain').checked = pluginSettings.displayRain;
             document.getElementById('displayRain').value = pluginSettings.displayRain;
-			
-			document.getElementById('displayGraphIcons').checked = pluginSettings.displayGraphIcons;
+
+	    document.getElementById('displayWind').checked = pluginSettings.displayWind;
+	    document.getElementById('displayWind').value = pluginSettings.displayWind;
+		
+	    document.getElementById('displaySunshine').checked = pluginSettings.displaySunshine === 'true';
+	    document.getElementById('displaySunshine').value = pluginSettings.displaySunshine || 'false';
+
+	    document.getElementById('displayGraphIcons').checked = pluginSettings.displayGraphIcons;
             document.getElementById('displayGraphIcons').value = pluginSettings.displayGraphIcons;
 			
             document.getElementById('displayForecast').checked = pluginSettings.displayForecast;
@@ -243,15 +258,19 @@
             document.getElementById('displayMetrics').value = "true";
             document.getElementById('displayGraph').checked = true;
             document.getElementById('displayGraph').value = "true";
-			document.getElementById('displayRain').checked = false;
+	    document.getElementById('displayRain').checked = false;
             document.getElementById('displayRain').value = "false";
-			document.getElementById('displayGraphIcons').checked = false;
-			document.getElementById('displayGraphIcons').value = "false";
+	    document.getElementById('displayWind').checked = false;
+	    document.getElementById('displayWind').value = "false";
+	    document.getElementById('displaySunshine').checked = false;
+	    document.getElementById('displaySunshine').value = "false";
+	    document.getElementById('displayGraphIcons').checked = false;
+	    document.getElementById('displayGraphIcons').value = "false";
             document.getElementById('displayForecast').checked = true;
             document.getElementById('displayForecast').value = "true";
             document.getElementById('forecastDays').value = 7;
             document.getElementById('moonPhase').checked = false;
-			document.getElementById('moonPhase').value = "false";
+	    document.getElementById('moonPhase').value = "false";
             document.getElementById('weatherTimeZone').value = "locationTimeZone";
         }
 

--- a/src/plugins/weather/settings.html
+++ b/src/plugins/weather/settings.html
@@ -226,9 +226,9 @@
 	    document.getElementById('displayRain').checked = pluginSettings.displayRain;
             document.getElementById('displayRain').value = pluginSettings.displayRain;
 
-	    document.getElementById('displayWind').checked = pluginSettings.displayWind;
-	    document.getElementById('displayWind').value = pluginSettings.displayWind;
-		
+	    document.getElementById('displayWind').checked = pluginSettings.displayWind === 'true';
+	    document.getElementById('displayWind').value = pluginSettings.displayWind || 'false';
+
 	    document.getElementById('displaySunshine').checked = pluginSettings.displaySunshine === 'true';
 	    document.getElementById('displaySunshine').value = pluginSettings.displaySunshine || 'false';
 

--- a/src/plugins/weather/weather.py
+++ b/src/plugins/weather/weather.py
@@ -512,9 +512,11 @@ class Weather(BasePlugin):
 
         wind_deg = weather.get('current', {}).get("wind_deg", 0)
         wind_arrow = self.get_wind_arrow(wind_deg)
+        wind_speed_raw = weather.get('current', {}).get("wind_speed", 0)
+        wind_speed = round(wind_speed_raw * 3.6, 1) if units != "imperial" else wind_speed_raw
         data_points.append({
             "label": "Wind",
-            "measurement": weather.get('current', {}).get("wind_speed"),
+            "measurement": wind_speed,
             "unit": UNITS[units]["speed"],
             "icon": self.get_plugin_dir('icons/wind.png'),
             "arrow": wind_arrow

--- a/src/plugins/weather/weather.py
+++ b/src/plugins/weather/weather.py
@@ -32,12 +32,12 @@ def get_moon_phase_name(phase_age: float) -> str:
 UNITS = {
     "standard": {
         "temperature": "K",
-        "speed": "m/s",
+        "speed": "km/h",
         "distance":"km"
     },
     "metric": {
         "temperature": "°C",
-        "speed": "m/s",
+        "speed": "km/h",
         "distance":"km"
 
     },
@@ -52,11 +52,11 @@ WEATHER_URL = "https://api.openweathermap.org/data/3.0/onecall?lat={lat}&lon={lo
 AIR_QUALITY_URL = "http://api.openweathermap.org/data/2.5/air_pollution?lat={lat}&lon={long}&appid={api_key}"
 GEOCODING_URL = "http://api.openweathermap.org/geo/1.0/reverse?lat={lat}&lon={long}&limit=1&appid={api_key}"
 
-OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={long}&hourly=weather_code,temperature_2m,precipitation,precipitation_probability,relative_humidity_2m,surface_pressure,visibility&daily=weathercode,temperature_2m_max,temperature_2m_min,sunrise,sunset&current=temperature,windspeed,winddirection,is_day,precipitation,weather_code,apparent_temperature&timezone=auto&models=best_match&forecast_days={forecast_days}"
+OPEN_METEO_FORECAST_URL = "https://api.open-meteo.com/v1/forecast?latitude={lat}&longitude={long}&hourly=weather_code,temperature_2m,precipitation,precipitation_probability,relative_humidity_2m,surface_pressure,visibility,wind_speed_10m,sunshine_duration&daily=weathercode,temperature_2m_max,temperature_2m_min,sunrise,sunset&current=temperature,windspeed,winddirection,is_day,precipitation,weather_code,apparent_temperature&timezone=auto&models=best_match&forecast_days={forecast_days}"
 OPEN_METEO_AIR_QUALITY_URL = "https://air-quality-api.open-meteo.com/v1/air-quality?latitude={lat}&longitude={long}&hourly=european_aqi,uv_index,uv_index_clear_sky&timezone=auto"
 OPEN_METEO_UNIT_PARAMS = {
-    "standard": "temperature_unit=celsius&wind_speed_unit=ms&precipitation_unit=mm",  # temperature is converted to Kelvin later
-    "metric":   "temperature_unit=celsius&wind_speed_unit=ms&precipitation_unit=mm",
+    "standard": "temperature_unit=celsius&wind_speed_unit=kmh&precipitation_unit=mm",  # temperature is converted to Kelvin later
+    "metric":   "temperature_unit=celsius&wind_speed_unit=kmh&precipitation_unit=mm",
     "imperial": "temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch"
 }
 
@@ -72,6 +72,16 @@ class Weather(BasePlugin):
         return template_params
 
     def generate_image(self, settings, device_config):
+        # Sanitize boolean settings to prevent float conversion errors
+        bool_settings = [
+            'displayRefreshTime', 'displayMetrics', 'displayGraph',
+            'displayRain', 'displayWind', 'displayGraphIcons',
+            'displayForecast', 'moonPhase'
+        ]
+        for key in bool_settings:
+            if settings.get(key, '') == '':
+                settings[key] = 'false'
+
         lat = float(settings.get('latitude'))
         long = float(settings.get('longitude'))
         if not lat or not long:
@@ -108,7 +118,7 @@ class Weather(BasePlugin):
                 forecast_days = 7
                 weather_data = self.get_open_meteo_data(lat, long, units, forecast_days + 1)
                 aqi_data = self.get_open_meteo_air_quality(lat, long)
-                template_params = self.parse_open_meteo_data(weather_data, aqi_data, tz, units, time_format, lat)
+                template_params = self.parse_open_meteo_data(weather_data, aqi_data, tz, units, time_format, lat, settings)
             else:
                 raise RuntimeError(f"Unknown weather provider: {weather_provider}")
 
@@ -164,7 +174,7 @@ class Weather(BasePlugin):
         data['hourly_forecast'] = self.parse_hourly(weather_data.get('hourly'), tz, time_format, units, daily_forecast)
         return data
 
-    def parse_open_meteo_data(self, weather_data, aqi_data, tz, units, time_format, lat):
+    def parse_open_meteo_data(self, weather_data, aqi_data, tz, units, time_format, lat, settings=None):
         current = weather_data.get("current", {})
         daily = weather_data.get('daily', {})
         dt = datetime.fromisoformat(current.get('time')).astimezone(tz) if current.get('time') else datetime.now(tz)
@@ -185,7 +195,7 @@ class Weather(BasePlugin):
         }
 
         data['forecast'] = self.parse_open_meteo_forecast(weather_data.get('daily', {}), units, tz, is_day, lat)
-        data['data_points'] = self.parse_open_meteo_data_points(weather_data, aqi_data, units, tz, time_format)
+        data['data_points'] = self.parse_open_meteo_data_points(weather_data, aqi_data, units, tz, time_format, settings)
         
         data['hourly_forecast'] = self.parse_open_meteo_hourly(weather_data.get('hourly', {}), units, tz, time_format, daily.get('sunrise', []), daily.get('sunset', []))
         return data
@@ -407,6 +417,7 @@ class Weather(BasePlugin):
                 "temperature": int(hour.get("temp")),
                 "precipitation": hour.get("pop"),
                 "rain": round(precip_value, 2),
+                "wind": round(hour.get("wind_speed", 0) * 3.6, 1) if units != "imperial" else hour.get("wind_speed", 0),
                 "icon": self.get_plugin_dir(f'icons/{icon_name}.png')
             }
             hourly.append(hour_forecast)
@@ -447,6 +458,10 @@ class Weather(BasePlugin):
         sliced_precipitation_probabilities = precipitation_probabilities[start_index:]
         sliced_rain = rain[start_index:]
         sliced_codes = codes[start_index:]
+        wind_speed = hourly_data.get('wind_speed_10m', [])
+        sliced_wind_speed = wind_speed[start_index:]
+        sunshine_duration = hourly_data.get('sunshine_duration', [])
+        sliced_sunshine = sunshine_duration[start_index:]
 
         for i in range(min(24, len(sliced_times))):
             dt = datetime.fromisoformat(sliced_times[i]).astimezone(tz)
@@ -461,6 +476,8 @@ class Weather(BasePlugin):
                 "temperature": int(sliced_temperatures[i]) if i < len(sliced_temperatures) else 0,
                 "precipitation": (sliced_precipitation_probabilities[i] / 100) if i < len(sliced_precipitation_probabilities) else 0,
                 "rain": (sliced_rain[i]) if i < len(sliced_rain) else 0,
+                "wind": (sliced_wind_speed[i]) if i < len(sliced_wind_speed) else 0,
+                "sunshine": min(1.0, round((sliced_sunshine[i] / 3600), 2)) if i < len(sliced_sunshine) and sliced_sunshine[i] is not None else 0.0,
                 "icon": self.get_plugin_dir(f"icons/{icon_name}.png")
             }
             hourly.append(hour_forecast)
@@ -553,7 +570,7 @@ class Weather(BasePlugin):
 
         return data_points
 
-    def parse_open_meteo_data_points(self, weather_data, aqi_data, units, tz, time_format):
+    def parse_open_meteo_data_points(self, weather_data, aqi_data, units, tz, time_format, settings=None):
         """Parses current data points from Open-Meteo API response."""
         data_points = []
         daily_data = weather_data.get('daily', {})
@@ -589,9 +606,10 @@ class Weather(BasePlugin):
             logger.error(f"Sunset not found in Open-Meteo response, this is expected for polar areas in midnight sun and polar night periods.")
 
         # Wind
-        wind_speed = current_data.get("windspeed", 0)
+        wind_speed_raw = current_data.get("windspeed", 0)
         wind_deg = current_data.get("winddirection", 0)
         wind_arrow = self.get_wind_arrow(wind_deg)
+        wind_speed = wind_speed_raw
         wind_unit = UNITS[units]["speed"]
         data_points.append({
             "label": "Wind", "measurement": wind_speed, "unit": wind_unit,


### PR DESCRIPTION
This PR adds several improvements to the Weather plugin, primarily for Open-Meteo users.

**Changes**

1. Sunshine duration overlay (Open-Meteo only)
Added `sunshine_duration` to the hourly forecast API request. The chart now displays sunshine as yellow bars on the same `y1` axis as precipitation probability (0–100%), giving users a quick visual indication of how sunny each hour will be. Controlled by a new Sunshine checkbox in the plugin settings.

2. Temperature curve — removed area fill
The yellow gradient fill under the temperature curve has been removed. The temperature is now shown as a clean orange line, reducing visual clutter and making the precipitation and sunshine overlays easier to read.

3. Wind speed unit consistency (Open-Meteo)
The Open-Meteo API is explicitly requested with `wind_speed_unit=kmh` (or `mph` for imperial) via the existing `OPEN_METEO_UNIT_PARAMS`. The wind value passed to the chart and the metrics panel now correctly reflects the unit already returned by the API, matching the `UNITS` dict label (`km/h` / `mph`).

4. Wind speed unit fix (OpenWeatherMap hourly)
OWM always returns wind speed in m/s regardless of the `units` parameter. The hourly parser now converts to km/h for metric/standard units, consistent with the current wind display in the metrics panel.

Screenshots
<img width="778" height="455" alt="image" src="https://github.com/user-attachments/assets/a8153342-c71a-4234-9ba7-cb72a91c36ed" />

Tested with
- Provider: Open-Meteo
- Units: Metric
- Device: Raspberry Pi Zero + Inky Impression
