### PR TITLE
add button task to manually transition to next plugin in the playlist

### DIFF
--- a/src/button_task.py
+++ b/src/button_task.py
@@ -1,0 +1,123 @@
+import logging
+import threading
+import time
+from datetime import timedelta
+
+logger = logging.getLogger(__name__)
+
+
+class ButtonTask:
+    """Watches Pimoroni Inky hardware buttons and triggers app actions."""
+
+    DEFAULT_BUTTON_A_GPIO = 5
+    DEFAULT_DEBOUNCE_SECONDS = 1.0
+    POLL_TIMEOUT_SECONDS = 0.25
+
+    def __init__(self, device_config, refresh_task):
+        self.device_config = device_config
+        self.refresh_task = refresh_task
+        self.thread = None
+        self.running = False
+        self.request = None
+        self.offsets = []
+        self.button_a_gpio = self.DEFAULT_BUTTON_A_GPIO
+        self.last_press_time = 0
+
+    def start(self):
+        """Start watching button A when button controls are enabled for Inky hardware."""
+        if not self.is_enabled():
+            logger.info("Button controls disabled or unsupported for this display type")
+            return False
+
+        if self.thread and self.thread.is_alive():
+            return True
+
+        self.running = True
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+        logger.info("Started Inky button task")
+        return True
+
+    def stop(self):
+        """Stop watching button events."""
+        self.running = False
+
+        if self.thread and self.thread.is_alive():
+            logger.info("Stopping Inky button task")
+            self.thread.join(timeout=2)
+
+        if self.thread and self.thread.is_alive():
+            self._close_request()
+
+    def is_enabled(self):
+        """Return whether button controls should run for the current config."""
+        if self.device_config.get_config("display_type", default="inky") != "inky":
+            return False
+
+        return True
+
+    def _run(self):
+        try:
+            self.request, self.offsets = self._request_button_lines()
+            while self.running:
+                for event in self._read_events(self.request):
+                    self._handle_button_event(event)
+        except ImportError as e:
+            logger.warning(f"Inky button controls unavailable; missing GPIO dependency: {e}")
+        except Exception:
+            logger.exception("Inky button task stopped after an unexpected error")
+        finally:
+            self.running = False
+            self._close_request()
+
+    def _request_button_lines(self):
+        import gpiod
+        import gpiodevice
+        from gpiod.line import Bias, Direction, Edge
+
+        self.button_a_gpio = int(self.device_config.get_config("button_a_gpio", default=self.DEFAULT_BUTTON_A_GPIO))
+        input_settings = gpiod.LineSettings(
+            direction=Direction.INPUT,
+            bias=Bias.PULL_UP,
+            edge_detection=Edge.FALLING,
+        )
+
+        chip = gpiodevice.find_chip_by_platform()
+        offsets = [chip.line_offset_from_id(self.button_a_gpio)]
+        line_config = dict.fromkeys(offsets, input_settings)
+        request = chip.request_lines(consumer="inkypi-buttons", config=line_config)
+        logger.info(f"Listening for Inky button A on GPIO {self.button_a_gpio}")
+        return request, offsets
+
+    def _read_events(self, request):
+        if hasattr(request, "wait_edge_events"):
+            if not request.wait_edge_events(timeout=timedelta(seconds=self.POLL_TIMEOUT_SECONDS)):
+                return []
+            return request.read_edge_events()
+
+        time.sleep(self.POLL_TIMEOUT_SECONDS)
+        return request.read_edge_events()
+
+    def _handle_button_event(self, event):
+        if not self.offsets or event.line_offset != self.offsets[0]:
+            return
+
+        now = time.monotonic()
+        debounce_seconds = float(
+            self.device_config.get_config("button_debounce_seconds", default=self.DEFAULT_DEBOUNCE_SECONDS)
+        )
+        if now - self.last_press_time < debounce_seconds:
+            logger.debug("Ignoring debounced Inky button A press")
+            return
+
+        self.last_press_time = now
+        logger.info(f"Inky button A pressed on GPIO {self.button_a_gpio}; cycling playlist")
+        self.refresh_task.cycle_playlist_next()
+
+    def _close_request(self):
+        if self.request and hasattr(self.request, "release"):
+            try:
+                self.request.release()
+            except Exception as e:
+                logger.debug(f"Error while releasing Inky button GPIO request: {e}")
+        self.request = None

--- a/src/inkypi.py
+++ b/src/inkypi.py
@@ -25,6 +25,7 @@ from werkzeug.serving import is_running_from_reloader
 from config import Config
 from display.display_manager import DisplayManager
 from refresh_task import RefreshTask
+from button_task import ButtonTask
 from blueprints.main import main_bp
 from blueprints.settings import settings_bp
 from blueprints.plugin import plugin_bp
@@ -63,6 +64,7 @@ app.jinja_loader = ChoiceLoader([FileSystemLoader(directory) for directory in te
 device_config = Config()
 display_manager = DisplayManager(device_config)
 refresh_task = RefreshTask(device_config, display_manager)
+button_task = ButtonTask(device_config, refresh_task)
 
 load_plugins(device_config.get_plugins())
 
@@ -70,6 +72,7 @@ load_plugins(device_config.get_plugins())
 app.config['DEVICE_CONFIG'] = device_config
 app.config['DISPLAY_MANAGER'] = display_manager
 app.config['REFRESH_TASK'] = refresh_task
+app.config['BUTTON_TASK'] = button_task
 
 # Set additional parameters
 app.config['MAX_FORM_PARTS'] = 10_000
@@ -88,6 +91,7 @@ if __name__ == '__main__':
 
     # start the background refresh task
     refresh_task.start()
+    button_task.start()
 
     # display default inkypi image on startup
     if device_config.get_config("startup") is True:
@@ -114,4 +118,5 @@ if __name__ == '__main__':
 
         serve(app, host="0.0.0.0", port=PORT, threads=1)
     finally:
+        button_task.stop()
         refresh_task.stop()

--- a/src/refresh_task.py
+++ b/src/refresh_task.py
@@ -24,6 +24,7 @@ class RefreshTask:
         self.condition = threading.Condition(self.lock)
         self.running = False
         self.manual_update_request = ()
+        self.playlist_cycle_requested = False
 
         self.refresh_event = threading.Event()
         self.refresh_event.set()
@@ -94,6 +95,17 @@ class RefreshTask:
                         logger.info("Manual update requested")
                         refresh_action = self.manual_update_request
                         self.manual_update_request = ()
+                    elif self.playlist_cycle_requested:
+                        logger.info("Manual playlist cycle requested")
+                        self.playlist_cycle_requested = False
+                        playlist, plugin_instance = self._determine_next_plugin(
+                            playlist_manager,
+                            latest_refresh,
+                            current_dt,
+                            ignore_cycle_interval=True
+                        )
+                        if plugin_instance:
+                            refresh_action = PlaylistRefresh(playlist, plugin_instance)
                     else:
 
                         if self.device_config.get_config("log_system_stats"):
@@ -149,6 +161,24 @@ class RefreshTask:
         else:
             logger.warning("Background refresh task is not running, unable to do a manual update")
 
+    def cycle_playlist_next(self, wait=False):
+        """Request an immediate cycle to the next plugin in the active playlist."""
+        if self.running:
+            with self.condition:
+                self.playlist_cycle_requested = True
+                self.refresh_result = {}
+                self.refresh_event.clear()
+                self.condition.notify_all()
+
+            if wait:
+                self.refresh_event.wait()
+                if self.refresh_result.get("exception"):
+                    raise self.refresh_result.get("exception")
+            return True
+
+        logger.warning("Background refresh task is not running, unable to cycle playlist")
+        return False
+
     def signal_config_change(self):
         """Notify the background thread that config has changed (e.g., interval updated)."""
         if self.running:
@@ -160,7 +190,7 @@ class RefreshTask:
         tz_str = self.device_config.get_config("timezone", default="UTC")
         return datetime.now(pytz.timezone(tz_str))
 
-    def _determine_next_plugin(self, playlist_manager, latest_refresh_info, current_dt):
+    def _determine_next_plugin(self, playlist_manager, latest_refresh_info, current_dt, ignore_cycle_interval=False):
         """Determines the next plugin to refresh based on the active playlist, plugin cycle interval, and current time."""
         playlist = playlist_manager.determine_active_playlist(current_dt)
         if not playlist:
@@ -175,7 +205,7 @@ class RefreshTask:
 
         latest_refresh_dt = latest_refresh_info.get_refresh_datetime()
         plugin_cycle_interval = self.device_config.get_config("plugin_cycle_interval_seconds", default=3600)
-        should_refresh = PlaylistManager.should_refresh(latest_refresh_dt, plugin_cycle_interval, current_dt)
+        should_refresh = ignore_cycle_interval or PlaylistManager.should_refresh(latest_refresh_dt, plugin_cycle_interval, current_dt)
 
         if not should_refresh:
             latest_refresh_str = latest_refresh_dt.strftime('%Y-%m-%d %H:%M:%S') if latest_refresh_dt else "None"

--- a/tests/test_button_task.py
+++ b/tests/test_button_task.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from button_task import ButtonTask
+
+
+class FakeConfig:
+    def __init__(self, values):
+        self.values = values
+
+    def get_config(self, key=None, default={}):
+        if key is None:
+            return self.values
+        return self.values.get(key, default)
+
+
+class FakeRefreshTask:
+    def __init__(self):
+        self.cycle_count = 0
+
+    def cycle_playlist_next(self):
+        self.cycle_count += 1
+
+
+class FakeEvent:
+    def __init__(self, line_offset):
+        self.line_offset = line_offset
+
+
+def test_button_task_is_enabled_only_for_inky_display():
+    refresh_task = FakeRefreshTask()
+
+    assert ButtonTask(FakeConfig({"display_type": "inky"}), refresh_task).is_enabled()
+    assert not ButtonTask(FakeConfig({"display_type": "mock"}), refresh_task).is_enabled()
+
+
+def test_button_a_press_cycles_playlist_and_debounces(monkeypatch):
+    refresh_task = FakeRefreshTask()
+    button_task = ButtonTask(
+        FakeConfig({
+            "display_type": "inky",
+            "button_debounce_seconds": 1.0,
+        }),
+        refresh_task,
+    )
+    button_task.offsets = [7]
+
+    times = iter([10.0, 10.5, 11.1])
+    monkeypatch.setattr("button_task.time.monotonic", lambda: next(times))
+
+    button_task._handle_button_event(FakeEvent(7))
+    button_task._handle_button_event(FakeEvent(7))
+    button_task._handle_button_event(FakeEvent(7))
+
+    assert refresh_task.cycle_count == 2
+
+
+def test_button_task_ignores_other_lines():
+    refresh_task = FakeRefreshTask()
+    button_task = ButtonTask(FakeConfig({"display_type": "inky"}), refresh_task)
+    button_task.offsets = [7]
+
+    button_task._handle_button_event(FakeEvent(8))
+
+    assert refresh_task.cycle_count == 0

--- a/tests/test_refresh_task.py
+++ b/tests/test_refresh_task.py
@@ -1,0 +1,95 @@
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from model import Playlist, PlaylistManager, RefreshInfo
+from refresh_task import RefreshTask
+
+
+class FakeConfig:
+    def __init__(self, interval_seconds=3600):
+        self.interval_seconds = interval_seconds
+
+    def get_config(self, key=None, default={}):
+        values = {
+            "plugin_cycle_interval_seconds": self.interval_seconds,
+            "timezone": "UTC",
+        }
+        if key is None:
+            return values
+        return values.get(key, default)
+
+
+def plugin_data(plugin_id, name):
+    return {
+        "plugin_id": plugin_id,
+        "name": name,
+        "plugin_settings": {},
+        "refresh": {},
+    }
+
+
+def test_determine_next_plugin_can_ignore_cycle_interval():
+    current_dt = datetime.now()
+    latest_refresh = RefreshInfo(
+        refresh_type="Playlist",
+        plugin_id="clock",
+        refresh_time=(current_dt - timedelta(seconds=30)).isoformat(),
+        image_hash="same-image",
+        playlist="Default",
+        plugin_instance="Clock",
+    )
+    playlist = Playlist(
+        "Default",
+        "00:00",
+        "24:00",
+        plugins=[
+            plugin_data("clock", "Clock"),
+            plugin_data("weather", "Weather"),
+        ],
+    )
+    playlist_manager = PlaylistManager([playlist])
+    refresh_task = RefreshTask(FakeConfig(interval_seconds=3600), display_manager=None)
+
+    inactive_playlist, inactive_plugin = refresh_task._determine_next_plugin(
+        playlist_manager,
+        latest_refresh,
+        current_dt,
+    )
+    assert inactive_playlist is None
+    assert inactive_plugin is None
+
+    active_playlist, active_plugin = refresh_task._determine_next_plugin(
+        playlist_manager,
+        latest_refresh,
+        current_dt,
+        ignore_cycle_interval=True,
+    )
+    assert active_playlist == playlist
+    assert active_plugin.name == "Clock"
+
+    _, next_plugin = refresh_task._determine_next_plugin(
+        playlist_manager,
+        latest_refresh,
+        current_dt,
+        ignore_cycle_interval=True,
+    )
+    assert next_plugin.name == "Weather"
+
+
+def test_cycle_playlist_next_signals_background_thread_without_rendering():
+    refresh_task = RefreshTask(FakeConfig(), display_manager=None)
+    refresh_task.running = True
+
+    assert refresh_task.cycle_playlist_next() is True
+    assert refresh_task.playlist_cycle_requested is True
+    assert not refresh_task.refresh_event.is_set()
+
+
+def test_cycle_playlist_next_returns_false_when_task_is_stopped():
+    refresh_task = RefreshTask(FakeConfig(), display_manager=None)
+
+    assert refresh_task.cycle_playlist_next() is False
+    assert refresh_task.playlist_cycle_requested is False


### PR DESCRIPTION
- Adds optional Pimoroni Inky button support so pressing button A manually advances the active plugin playlist.
- Routes manual playlist cycling through the existing refresh thread to avoid display/config write races.
- Adds safe config defaults plus tests for forced playlist cycling and button debounce behavior.