### PR TITLE
Add Unsplash illustration collection mode (and fix import)

### DIFF
--- a/src/plugins/unsplash/settings.html
+++ b/src/plugins/unsplash/settings.html
@@ -11,6 +11,16 @@
 </div>
 
 <div class="form-group">
+    <label for="asset_type" class="form-label">Content Type:</label>
+    <select id="asset_type" name="asset_type" class="form-input">
+        <option value="photo">Photos</option>
+        <option value="illustration">Illustrations from collections</option>
+        <option value="mixed">Photos and illustrations from collections</option>
+    </select>
+    <small style="width: 100%; color: var(--text-primary);">Illustrations and mixed mode require collection IDs and do not support search query.</small>
+</div>
+
+<div class="form-group">
     <div class="form-group">
         <label for="content_filter" class="form-label">Content Filter:</label>
         <select id="content_filter" name="content_filter" class="form-input">
@@ -53,6 +63,7 @@
         if (loadPluginSettings) {
             document.getElementById('search_query').value = pluginSettings.search_query || '';
             document.getElementById('collections').value = pluginSettings.collections || '';
+            document.getElementById('asset_type').value = pluginSettings.asset_type || 'photo';
             document.getElementById('content_filter').value = pluginSettings.content_filter || 'low';
             document.getElementById('color').value = pluginSettings.color || '';
             document.getElementById('orientation').value = pluginSettings.orientation || '';

--- a/src/plugins/unsplash/unsplash.py
+++ b/src/plugins/unsplash/unsplash.py
@@ -3,10 +3,16 @@ from utils.image_loader import _is_low_resource_device
 from utils.http_client import get_http_session
 import logging
 import random
+import requests
 
 logger = logging.getLogger(__name__)
 
 class Unsplash(BasePlugin):
+    PHOTO_ASSET_TYPE = 'photo'
+    ILLUSTRATION_ASSET_TYPE = 'illustration'
+    MIXED_ASSET_TYPE = 'mixed'
+    COLLECTION_ASSET_TYPES = {PHOTO_ASSET_TYPE, ILLUSTRATION_ASSET_TYPE}
+
     def generate_image(self, settings, device_config):
         logger.info("=== Unsplash Plugin: Starting image generation ===")
 
@@ -20,13 +26,15 @@ class Unsplash(BasePlugin):
         content_filter = settings.get('content_filter', 'low')
         color = settings.get('color')
         orientation = settings.get('orientation')
+        asset_type = settings.get('asset_type', self.PHOTO_ASSET_TYPE)
+        asset_type = (asset_type or self.PHOTO_ASSET_TYPE).strip().lower()
 
         # Automatically determine image size based on device capabilities
         is_low_resource = _is_low_resource_device()
         image_size = 'regular' if is_low_resource else 'full'
         logger.info(f"Device type: {'low-resource' if is_low_resource else 'standard'}, using image size: '{image_size}'")
 
-        logger.info(f"Settings: image_size='{image_size}', content_filter='{content_filter}'")
+        logger.info(f"Settings: image_size='{image_size}', content_filter='{content_filter}', asset_type='{asset_type}'")
         if search_query:
             logger.info(f"Search query: '{search_query}'")
         if collections:
@@ -36,53 +44,35 @@ class Unsplash(BasePlugin):
         if orientation:
             logger.debug(f"Orientation: {orientation}")
 
-        params = {
-            'client_id': access_key,
-            'content_filter': content_filter,
-            'per_page': 100,
-        }
+        if asset_type not in {self.PHOTO_ASSET_TYPE, self.ILLUSTRATION_ASSET_TYPE, self.MIXED_ASSET_TYPE}:
+            logger.error(f"Unknown Unsplash asset_type setting: {asset_type}")
+            raise RuntimeError("Unknown Unsplash asset type setting.")
 
-        if search_query:
-            url = f"https://api.unsplash.com/search/photos"
-            params['query'] = search_query
-            logger.debug(f"Using search endpoint: {url}")
-        else:
-            url = f"https://api.unsplash.com/photos/random"
-            logger.debug(f"Using random photo endpoint: {url}")
+        if asset_type in {self.ILLUSTRATION_ASSET_TYPE, self.MIXED_ASSET_TYPE} and search_query:
+            logger.error("Search query is only supported for Unsplash photos mode")
+            raise RuntimeError("Search query is only supported for Unsplash photos mode.")
 
-        if collections:
-            params['collections'] = collections
-        if color:
-            params['color'] = color
-        if orientation:
-            params['orientation'] = orientation
+        if asset_type in {self.ILLUSTRATION_ASSET_TYPE, self.MIXED_ASSET_TYPE} and not collections:
+            logger.error("Collections are required for Unsplash illustration and mixed modes")
+            raise RuntimeError("Collections are required for Unsplash illustration and mixed modes.")
 
         try:
             logger.debug("Fetching image from Unsplash API...")
             session = get_http_session()
-            response = session.get(url, params=params)
-            response.raise_for_status()
-            data = response.json()
 
-            if search_query:
-                results = data.get("results")
-                if not results:
-                    logger.warning(f"No images found for search query: '{search_query}'")
-                    raise RuntimeError("No images found for the given search query.")
-                logger.info(f"Found {len(results)} images matching search query")
-                # Use selected image size (with automatic downgrade for low-RAM devices)
-                selected_photo = random.choice(results)
-                image_url = selected_photo["urls"][image_size]
-                logger.debug(f"Selected random image from {len(results)} results")
+            if asset_type == self.PHOTO_ASSET_TYPE:
+                selected_item = self._fetch_photo(session, access_key, search_query, collections, content_filter, color, orientation)
             else:
-                # Use selected image size (with automatic downgrade for low-RAM devices)
-                image_url = data["urls"][image_size]
-                logger.debug("Retrieved random image URL")
+                selected_item = self._fetch_collection_item(session, access_key, collections, orientation, asset_type)
+
+            # Use selected image size (with automatic downgrade for low-RAM devices)
+            image_url = self._get_image_url(selected_item, image_size)
+            logger.debug(f"Selected Unsplash {self._detect_asset_type(selected_item)} URL")
 
         except requests.exceptions.RequestException as e:
             logger.error(f"Error fetching image from Unsplash API: {e}")
             raise RuntimeError("Failed to fetch image from Unsplash API, please check logs.")
-        except (KeyError, IndexError) as e:
+        except (KeyError, IndexError, TypeError) as e:
             logger.error(f"Error parsing Unsplash API response: {e}")
             raise RuntimeError("Failed to parse Unsplash API response, please check logs.")
 
@@ -103,3 +93,101 @@ class Unsplash(BasePlugin):
 
         logger.info("=== Unsplash Plugin: Image generation complete ===")
         return image
+
+    def _fetch_photo(self, session, access_key, search_query, collections, content_filter, color, orientation):
+        params = {
+            'client_id': access_key,
+            'content_filter': content_filter,
+            'per_page': 100,
+        }
+
+        if search_query:
+            url = "https://api.unsplash.com/search/photos"
+            params['query'] = search_query
+            logger.debug(f"Using search endpoint: {url}")
+        else:
+            url = "https://api.unsplash.com/photos/random"
+            logger.debug(f"Using random photo endpoint: {url}")
+
+        if collections:
+            params['collections'] = collections
+        if color:
+            params['color'] = color
+        if orientation:
+            params['orientation'] = orientation
+
+        response = session.get(url, params=params)
+        response.raise_for_status()
+        data = response.json()
+
+        if not search_query:
+            logger.debug("Retrieved random photo")
+            return data
+
+        results = data.get("results")
+        if not results:
+            logger.warning(f"No images found for search query: '{search_query}'")
+            raise RuntimeError("No images found for the given search query.")
+
+        logger.info(f"Found {len(results)} images matching search query")
+        logger.debug(f"Selected random image from {len(results)} results")
+        return random.choice(results)
+
+    def _fetch_collection_item(self, session, access_key, collections, orientation, asset_type):
+        collection_ids = [collection_id.strip() for collection_id in collections.split(',') if collection_id.strip()]
+        if not collection_ids:
+            logger.error("No usable Unsplash collection IDs configured")
+            raise RuntimeError("No usable Unsplash collection IDs configured.")
+
+        wanted_asset_types = self.COLLECTION_ASSET_TYPES if asset_type == self.MIXED_ASSET_TYPE else {asset_type}
+        candidates = []
+
+        for collection_id in collection_ids:
+            url = f"https://api.unsplash.com/collections/{collection_id}/photos"
+            params = {
+                'client_id': access_key,
+                'per_page': 30,
+            }
+            if orientation:
+                params['orientation'] = orientation
+
+            logger.debug(f"Using collection endpoint for {collection_id}: {url}")
+            response = session.get(url, params=params)
+            response.raise_for_status()
+            collection_items = response.json()
+
+            matching_items = [
+                item for item in collection_items
+                if self._detect_asset_type(item) in wanted_asset_types and item.get('urls')
+            ]
+            logger.info(f"Found {len(matching_items)} {asset_type} candidates in collection {collection_id}")
+            candidates.extend(matching_items)
+
+        if not candidates:
+            logger.warning(f"No Unsplash {asset_type} items found in configured collections: {collections}")
+            raise RuntimeError(f"No Unsplash {asset_type} items found in the configured collections.")
+
+        logger.info(f"Selected random {asset_type} item from {len(candidates)} collection candidates")
+        return random.choice(candidates)
+
+    def _detect_asset_type(self, item):
+        asset_type = item.get('asset_type')
+        if asset_type:
+            return asset_type
+
+        self_link = item.get('links', {}).get('self', '')
+        if '/illustrations/' in self_link:
+            return self.ILLUSTRATION_ASSET_TYPE
+
+        return self.PHOTO_ASSET_TYPE
+
+    def _get_image_url(self, item, image_size):
+        urls = item.get('urls') or {}
+        fallback_order = [image_size, 'regular', 'small', 'full', 'raw']
+
+        for key in dict.fromkeys(fallback_order):
+            image_url = urls.get(key)
+            if image_url:
+                return image_url
+
+        raise KeyError(f"No usable image URL found for Unsplash item {item.get('id')}")

--- a/tests/test_unsplash_plugin.py
+++ b/tests/test_unsplash_plugin.py
@@ -1,0 +1,195 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+sys.path.insert(0, str(SRC))
+sys.path.insert(0, str(ROOT))
+
+from plugins.unsplash import unsplash as unsplash_module
+from plugins.unsplash.unsplash import Unsplash
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self.data = data
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.data
+
+
+class DummySession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, url, params=None):
+        self.calls.append((url, dict(params or {})))
+        return self.responses.pop(0)
+
+
+class TestUnsplashPlugin(unittest.TestCase):
+    def setUp(self):
+        self.device_config = MagicMock()
+        self.device_config.load_env_key.return_value = "access-key"
+        self.device_config.get_resolution.return_value = (800, 480)
+        self.device_config.get_config.return_value = "horizontal"
+
+        low_resource_patcher = patch.object(unsplash_module, "_is_low_resource_device", return_value=True)
+        low_resource_patcher.start()
+        self.addCleanup(low_resource_patcher.stop)
+
+        self.plugin = Unsplash({"id": "unsplash"})
+
+        self.plugin.image_loader = MagicMock()
+        self.plugin.image_loader.from_url.return_value = "image"
+
+    def test_photo_mode_keeps_random_photo_endpoint(self):
+        session = DummySession([
+            DummyResponse({
+                "id": "photo-id",
+                "asset_type": "photo",
+                "urls": {
+                    "regular": "https://example.test/photo-regular.jpg",
+                    "full": "https://example.test/photo-full.jpg",
+                },
+            })
+        ])
+
+        with patch.object(unsplash_module, "get_http_session", return_value=session):
+            result = self.plugin.generate_image({
+                "asset_type": "photo",
+                "collections": "abc",
+                "content_filter": "low",
+            }, self.device_config)
+
+        self.assertEqual(result, "image")
+        self.assertEqual(session.calls, [(
+            "https://api.unsplash.com/photos/random",
+            {
+                "client_id": "access-key",
+                "content_filter": "low",
+                "per_page": 100,
+                "collections": "abc",
+            },
+        )])
+        self.plugin.image_loader.from_url.assert_called_once_with(
+            "https://example.test/photo-regular.jpg",
+            (800, 480),
+            timeout_ms=40000,
+        )
+
+    def test_illustration_mode_uses_collection_endpoint(self):
+        session = DummySession([
+            DummyResponse([
+                {
+                    "id": "photo-id",
+                    "asset_type": "photo",
+                    "urls": {"regular": "https://example.test/photo.jpg"},
+                },
+                {
+                    "id": "illustration-id",
+                    "asset_type": "illustration",
+                    "urls": {"regular": "https://example.test/illustration.jpg"},
+                },
+            ])
+        ])
+
+        with patch.object(unsplash_module, "get_http_session", return_value=session):
+            result = self.plugin.generate_image({
+                "asset_type": "illustration",
+                "collections": "Vwmvy6UieVg",
+                "color": "blue",
+                "orientation": "portrait",
+            }, self.device_config)
+
+        self.assertEqual(result, "image")
+        self.assertEqual(session.calls, [(
+            "https://api.unsplash.com/collections/Vwmvy6UieVg/photos",
+            {
+                "client_id": "access-key",
+                "per_page": 30,
+                "orientation": "portrait",
+            },
+        )])
+        self.plugin.image_loader.from_url.assert_called_once_with(
+            "https://example.test/illustration.jpg",
+            (800, 480),
+            timeout_ms=40000,
+        )
+
+    def test_mixed_mode_combines_multiple_collections(self):
+        session = DummySession([
+            DummyResponse([
+                {
+                    "id": "photo-id",
+                    "links": {"self": "https://api.unsplash.com/photos/photo-id"},
+                    "urls": {"regular": "https://example.test/photo.jpg"},
+                },
+            ]),
+            DummyResponse([
+                {
+                    "id": "illustration-id",
+                    "links": {"self": "https://api.unsplash.com/illustrations/illustration-id"},
+                    "urls": {"regular": "https://example.test/illustration.jpg"},
+                },
+            ]),
+        ])
+
+        with patch.object(unsplash_module, "get_http_session", return_value=session):
+            with patch.object(unsplash_module.random, "choice", side_effect=lambda items: items[-1]):
+                result = self.plugin.generate_image({
+                    "asset_type": "mixed",
+                    "collections": "photos, illustrations",
+                }, self.device_config)
+
+        self.assertEqual(result, "image")
+        self.assertEqual([call[0] for call in session.calls], [
+            "https://api.unsplash.com/collections/photos/photos",
+            "https://api.unsplash.com/collections/illustrations/photos",
+        ])
+        self.plugin.image_loader.from_url.assert_called_once_with(
+            "https://example.test/illustration.jpg",
+            (800, 480),
+            timeout_ms=40000,
+        )
+
+    def test_illustration_mode_rejects_search_query(self):
+        session = DummySession([])
+
+        with patch.object(unsplash_module, "get_http_session", return_value=session):
+            with self.assertRaisesRegex(RuntimeError, "Search query is only supported"):
+                self.plugin.generate_image({
+                    "asset_type": "illustration",
+                    "collections": "Vwmvy6UieVg",
+                    "search_query": "food",
+                }, self.device_config)
+
+        self.assertEqual(session.calls, [])
+
+    def test_illustration_mode_errors_when_collection_has_no_matches(self):
+        session = DummySession([
+            DummyResponse([
+                {
+                    "id": "photo-id",
+                    "asset_type": "photo",
+                    "urls": {"regular": "https://example.test/photo.jpg"},
+                },
+            ])
+        ])
+
+        with patch.object(unsplash_module, "get_http_session", return_value=session):
+            with self.assertRaisesRegex(RuntimeError, "No Unsplash illustration items"):
+                self.plugin.generate_image({
+                    "asset_type": "illustration",
+                    "collections": "photos-only",
+                }, self.device_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR updates the Unsplash plugin so it can load not only regular photos, but also Unsplash `illustration` assets from collections.

Previously, the plugin used `/photos/random` when no search query was provided. That works for photo collections, but Unsplash does not return `asset_type: illustration` items through that endpoint. Collections that contain only illustrations therefore failed with `No photos found`, even though `/collections/{id}/photos` returned valid items.

The plugin now supports an explicit content type setting:

- `Photos` keeps the existing behavior.
- `Illustrations from collections` loads only `asset_type: illustration` items.
- `Photos and illustrations from collections` loads both photos and illustrations.

**Key Changes**
- Added `asset_type` handling in `src/plugins/unsplash/unsplash.py`.
- Preserved existing photo behavior via:
  - `/search/photos` when `search_query` is set.
  - `/photos/random` otherwise.
- Added collection-based loading for `illustration` and `mixed` modes using:
  - `/collections/{collection_id}/photos`
- Added support for multiple comma-separated collection IDs.
- Added filtering by `asset_type`.
- Added image URL fallback order:
  - selected size (`regular` on low-resource devices, `full` otherwise)
  - `regular`
  - `small`
  - `full`
  - `raw`
- Added clear runtime errors for invalid combinations:
  - `illustration` or `mixed` without collections.
  - `illustration` or `mixed` with `search_query`.
  - collections with no matching assets.
- Updated `src/plugins/unsplash/settings.html` with a new `Content Type` select.
- Added `tests/test_unsplash_plugin.py` covering the new behavior.

**Behavior Notes**
- Illustration support intentionally uses the documented collection photos endpoint rather than an undocumented `/illustrations/random` endpoint.
- Search remains photo-only because Unsplash’s documented public search endpoint is `/search/photos`.
- In collection-based `illustration` and `mixed` modes, `orientation` is passed through, but `color` is not sent because the collection photos endpoint does not document a `color` parameter.
- No separate SVG/vector conversion is needed: Unsplash returns raster image URLs in `urls.regular`, `urls.full`, etc., and the existing image loader already downloads and converts them through Pillow.

**Testing**
Ran:

```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_unsplash_plugin -v
```

Result:

```text
Ran 5 tests in 0.054s

OK
```

Covered scenarios:
- Existing photo random endpoint behavior is preserved.
- Illustration mode uses collection endpoint and selects only illustrations.
- Mixed mode combines photos and illustrations across multiple collections.
- Illustration mode rejects `search_query`.
- Empty/no-match illustration collections produce a clear error.
