### PR TITLE
Fix init() crash on Waveshare grayscale displays (epd3in7)

### DIFF
--- a/src/display/waveshare_display.py
+++ b/src/display/waveshare_display.py
@@ -10,6 +10,12 @@ from plugins.plugin_registry import get_plugin_instance
 
 logger = logging.getLogger(__name__)
 
+# Some Waveshare drivers (e.g. epd3in7) require a display "mode" argument for
+# init()/Clear() and expose mode specific render methods (display_1Gray /
+# display_4Gray) instead of a generic display(). We drive those displays in
+# 1 grayscale (monochrome) mode, which mirrors the standard single-color path.
+GRAYSCALE_MODE = 1
+
 
 def split_image_for_bi_color_epd(image):
     """
@@ -80,15 +86,28 @@ class WaveshareDisplay(AbstractDisplay):
             if not callable(self.epd_display_init):
                 raise AttributeError("No Init/init method found")
 
+            # Drivers such as epd3in7 require a 'mode' argument for init(). Detect
+            # this and drive the display in 1 grayscale (monochrome) mode so the
+            # init() call no longer fails with a missing positional argument.
+            mode_param = inspect.signature(self.epd_display_init).parameters.get("mode")
+            self.grayscale_mode_display = (
+                mode_param is not None and mode_param.default is inspect.Parameter.empty
+            )
+            if self.grayscale_mode_display:
+                init_method = self.epd_display_init
+                self.epd_display_init = lambda: init_method(GRAYSCALE_MODE)
+
             self.epd_display_init()
 
-            display_args_spec = inspect.getfullargspec(self.epd_display.display)
+            if self.grayscale_mode_display:
+                self.bi_color_display = False
+            else:
+                display_args_spec = inspect.getfullargspec(self.epd_display.display)
+                self.bi_color_display = len(display_args_spec.args) > 2
         except ModuleNotFoundError:
             raise ValueError(f"Unsupported Waveshare display type: {display_type}")
         except AttributeError:
             raise ValueError(f"Display does not support required methods: {display_type}")
-
-        self.bi_color_display = len(display_args_spec.args) > 2
 
         # update the resolution directly from the loaded device context
         if not self.device_config.get_config("resolution"):
@@ -123,19 +142,24 @@ class WaveshareDisplay(AbstractDisplay):
         # Assume device was in sleep mode.
         self.epd_display_init()
 
-        # Clear residual pixels before updating the image.
-        self.epd_display.Clear()
-
-        # Display the image on the WS display.
-        if not self.bi_color_display:
-            self.epd_display.display(self.epd_display.getbuffer(image))
+        if self.grayscale_mode_display:
+            # Drivers such as epd3in7 use mode specific Clear/display methods.
+            self.epd_display.Clear(0xFF, GRAYSCALE_MODE)
+            self.epd_display.display_1Gray(self.epd_display.getbuffer(image))
         else:
-            black_layer, red_layer = split_image_for_bi_color_epd(image)
+            # Clear residual pixels before updating the image.
+            self.epd_display.Clear()
 
-            self.epd_display.display(
-                self.epd_display.getbuffer(black_layer),
-                self.epd_display.getbuffer(red_layer),
-            )
+            # Display the image on the WS display.
+            if not self.bi_color_display:
+                self.epd_display.display(self.epd_display.getbuffer(image))
+            else:
+                black_layer, red_layer = split_image_for_bi_color_epd(image)
+
+                self.epd_display.display(
+                    self.epd_display.getbuffer(black_layer),
+                    self.epd_display.getbuffer(red_layer),
+                )
 
         # Put device into low power mode (EPD displays maintain image when powered off)
         logger.info("Putting Waveshare display into sleep mode for power saving.")

--- a/tests/test_waveshare_display.py
+++ b/tests/test_waveshare_display.py
@@ -1,0 +1,128 @@
+import os
+import sys
+import types
+
+import pytest
+
+# waveshare_display.py uses absolute imports rooted at src (e.g. "display.*"),
+# so put src on the path to import it the same way the app does.
+SRC_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
+
+from display.waveshare_display import WaveshareDisplay  # noqa: E402
+
+
+class FakeDeviceConfig:
+    """Minimal device_config stub for exercising WaveshareDisplay."""
+
+    def __init__(self, display_type):
+        self._values = {"display_type": display_type}
+
+    def get_config(self, key, default=None):
+        return self._values.get(key, default)
+
+    def update_value(self, key, value, write=False):
+        self._values[key] = value
+
+
+class FakeEpd3in7:
+    """Mimics the waveshare epd3in7 driver API (init(mode), Clear(color, mode),
+    display_1Gray, no generic display())."""
+
+    width = 280
+    height = 480
+
+    def __init__(self):
+        self.calls = []
+
+    def init(self, mode):
+        self.calls.append(("init", mode))
+        return 0
+
+    def getbuffer(self, image):
+        self.calls.append(("getbuffer", image))
+        return b"buf"
+
+    def display_1Gray(self, image):
+        self.calls.append(("display_1Gray", image))
+
+    def Clear(self, color, mode):
+        self.calls.append(("Clear", color, mode))
+
+    def sleep(self):
+        self.calls.append(("sleep",))
+
+
+class FakeMonoEpd:
+    """Mimics a standard single-color driver (init(), Clear(), display(buf))."""
+
+    width = 800
+    height = 480
+
+    def __init__(self):
+        self.calls = []
+
+    def init(self):
+        self.calls.append(("init",))
+        return 0
+
+    def getbuffer(self, image):
+        return b"buf"
+
+    def display(self, buf):
+        self.calls.append(("display", buf))
+
+    def Clear(self):
+        self.calls.append(("Clear",))
+
+    def sleep(self):
+        self.calls.append(("sleep",))
+
+
+def _register_fake_driver(monkeypatch, display_type, epd_cls):
+    module = types.ModuleType(f"display.waveshare_epd.{display_type}")
+    module.EPD = epd_cls
+    monkeypatch.setitem(sys.modules, f"display.waveshare_epd.{display_type}", module)
+
+
+def test_epd3in7_init_passes_mode_argument(monkeypatch):
+    _register_fake_driver(monkeypatch, "epd3in7", FakeEpd3in7)
+
+    display = WaveshareDisplay(FakeDeviceConfig("epd3in7"))
+
+    assert display.grayscale_mode_display is True
+    assert display.bi_color_display is False
+    # init() must be called with the required mode argument (regression for #525).
+    assert display.epd_display.calls == [("init", 1)]
+    # resolution should be derived from the driver dimensions (landscape).
+    assert display.device_config.get_config("resolution") == [480, 280]
+
+
+def test_epd3in7_display_uses_mode_specific_methods(monkeypatch):
+    _register_fake_driver(monkeypatch, "epd3in7", FakeEpd3in7)
+
+    display = WaveshareDisplay(FakeDeviceConfig("epd3in7"))
+    display.epd_display.calls.clear()
+
+    display.display_image(object())
+
+    methods = [call[0] for call in display.epd_display.calls]
+    assert methods == ["init", "Clear", "getbuffer", "display_1Gray", "sleep"]
+    assert ("init", 1) in display.epd_display.calls
+    assert ("Clear", 0xFF, 1) in display.epd_display.calls
+
+
+def test_standard_mono_display_unaffected(monkeypatch):
+    _register_fake_driver(monkeypatch, "epd7in5_V2", FakeMonoEpd)
+
+    display = WaveshareDisplay(FakeDeviceConfig("epd7in5_V2"))
+
+    assert display.grayscale_mode_display is False
+    assert display.bi_color_display is False
+
+    display.epd_display.calls.clear()
+    display.display_image(object())
+
+    methods = [call[0] for call in display.epd_display.calls]
+    assert methods == ["init", "Clear", "display", "sleep"]


### PR DESCRIPTION
Fixes #525.

Some Waveshare drivers like epd3in7 take a required `mode` argument on `init()` and render through mode-specific methods (`Clear(color, mode)` / `display_1Gray`) instead of the generic `display()`, so `init()` was raising `TypeError: EPD.init() missing 1 required positional argument: 'mode'`.

This detects that case from the driver's `init` signature and drives those panels in 1Gray (monochrome) mode, which lines up with the existing single-color path. Standard mono and bi-color displays are untouched.

Added tests for the epd3in7 init/display path plus a regression check that standard mono displays are unaffected. The new tests pass (3 passed) and the existing suite stays green (28 passed).