### PR TITLE
Fix "OSError: [Errno 9] Bad file descriptor" for Waveshare EPDs

### DIFF
--- a/src/display/waveshare_display.py
+++ b/src/display/waveshare_display.py
@@ -72,8 +72,8 @@ class WaveshareDisplay(AbstractDisplay):
 
         try:
             # Dynamically load module
-            epd_module = importlib.import_module(module_name)  
-            self.epd_display = epd_module.EPD()
+            self.epd_module = importlib.import_module(module_name)  
+            self.epd_display = self.epd_module.EPD()
             # Workaround for init functions with inconsistent casing
             self.epd_display_init = getattr(self.epd_display, "Init", getattr(self.epd_display, "init", None))
 
@@ -98,6 +98,27 @@ class WaveshareDisplay(AbstractDisplay):
                 "resolution",
                 resolution,
                 write=True)
+            
+    def reinitialize_display(self):
+
+        """
+        Re-initializes the Waveshare display device.
+
+        Waveshare EPDs may require re-initialization after entering sleep mode. This is 
+        achieved by calling the EPD() constructor and init method again. 
+        
+        Not doing this results in "OSError: [Errno 9] Bad file descriptor" because the 
+        SPI file descriptor is closed by waveshare's epdconfig sleep() command.
+        """
+
+        self.epd_display = self.epd_module.EPD()
+        # Workaround for init functions with inconsistent casing
+        self.epd_display_init = getattr(self.epd_display, "Init", getattr(self.epd_display, "init", None))
+
+        if not callable(self.epd_display_init):
+            raise AttributeError("No Init/init method found")
+
+        self.epd_display_init()
 
 
     def display_image(self, image, image_settings=[]):

--- a/src/display/waveshare_display.py
+++ b/src/display/waveshare_display.py
@@ -142,7 +142,7 @@ class WaveshareDisplay(AbstractDisplay):
             raise ValueError(f"No image provided.")
 
         # Assume device was in sleep mode.
-        self.epd_display_init()
+        self.reinitialize_display()
 
         # Clear residual pixels before updating the image.
         self.epd_display.Clear()


### PR DESCRIPTION
Waveshare EPDs fully close the SPI file descriptor when being put to sleep. 
This result in `OSError: [Errno 9] Bad file descriptor` when diplay_image is called a second time. See https://github.com/fatihak/InkyPi/issues/452, https://github.com/fatihak/InkyPi/issues/259.

It can be discussed whether this is a bug in the waveshare drivers or intended behavior. However the fix proposed in https://github.com/fatihak/InkyPi/issues/259 has been an open PR (https://github.com/waveshareteam/e-Paper/issues/406) for half a year now without any reactions, so it can be assumed to not get fixed.

So heres the fix for this implementation:
The epd_module.EPD() constructor has to be called again for each display_image step. 
For this i implemented a small reinitialize_display function for the waveshare_display which recreates the epd_display each time display_image is called.
To safe resources I made the dynamic module import an Object field to be reusable.


I can confirm this code to work for the epd13in3k model and this model alone, as it's the only one I own.
But when looking into the waveshare epd drivers, the relevant piece of code is present for every model. 

