### PR TITLE
Implement automatic photo fitting feature with migration support

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 from datetime import datetime, timedelta
+from utils.settings_migrations import migrate_plugin_settings
 
 logger = logging.getLogger(__name__)
 
@@ -287,6 +288,14 @@ class PluginInstance:
         self.settings = settings
         self.refresh = refresh
         self.latest_refresh_time = latest_refresh_time
+
+    @property
+    def settings(self):
+        return self._settings
+
+    @settings.setter
+    def settings(self, value):
+        self._settings = migrate_plugin_settings(self.plugin_id, value)
 
     def update(self, updated_data):
         """Update attributes of the class with the dictionary values."""

--- a/src/plugins/image_album/image_album.py
+++ b/src/plugins/image_album/image_album.py
@@ -1,10 +1,9 @@
 import logging
 from random import choice
 
-from PIL import Image, ImageColor, ImageOps
+from PIL import Image
 from utils.http_client import get_http_session
 from plugins.base_plugin.base_plugin import BasePlugin
-from utils.image_utils import pad_image_blur
 
 logger = logging.getLogger(__name__)
 
@@ -53,14 +52,24 @@ class ImmichProvider:
         logger.debug(f"Found {len(all_items)} total assets in album")
         return all_items
 
-    def get_image(self, album: str, dimensions: tuple[int, int], resize: bool = True) -> Image.Image | None:
+    def get_image(
+        self,
+        album: str,
+        dimensions: tuple[int, int],
+        *,
+        fit_mode: str | None = None,
+        background_option: str = "blur",
+        background_color: str | None = None,
+    ) -> Image.Image | None:
         """
         Get a random image from the album.
 
         Args:
             album: Album name
             dimensions: Target dimensions (width, height)
-            resize: Whether to let loader resize (False when padding will be applied)
+            fit_mode: Optional cover, contain, or automatic fitting mode
+            background_option: Background style for contained images
+            background_color: Solid background color when selected
 
         Returns:
             PIL Image or None on error
@@ -87,14 +96,14 @@ class ImmichProvider:
         logger.info(f"Selected random asset: {asset_id}")
         logger.debug(f"Downloading from: {asset_url}")
 
-        # Use adaptive image loader for memory-efficient processing
-        # Let loader resize when requested (when no padding will be applied)
         img = self.image_loader.from_url(
             asset_url,
             dimensions,
             timeout_ms=40000,
-            resize=resize,
-            headers=self.headers
+            headers=self.headers,
+            fit_mode=fit_mode,
+            background_option=background_option,
+            background_color=background_color,
         )
 
         if not img:
@@ -129,10 +138,9 @@ class ImageAlbum(BasePlugin):
         album_provider = settings.get("albumProvider")
         logger.info(f"Album provider: {album_provider}")
 
-        # Check padding options to determine resize strategy
-        use_padding = settings.get('padImage') == "true"
+        fit_mode = settings.get("fitMode", "cover")
         background_option = settings.get('backgroundOption', 'blur')
-        logger.debug(f"Settings: pad_image={use_padding}, background_option={background_option}")
+        logger.debug(f"Settings: fit_mode={fit_mode}, background_option={background_option}")
 
         match album_provider:
             case "Immich":
@@ -155,8 +163,13 @@ class ImageAlbum(BasePlugin):
                 logger.info(f"Album: {album}")
 
                 provider = ImmichProvider(url, key, self.image_loader)
-                # Let loader resize when no padding needed, otherwise load full-size for padding
-                img = provider.get_image(album, dimensions, resize=not use_padding)
+                img = provider.get_image(
+                    album,
+                    dimensions,
+                    fit_mode=fit_mode,
+                    background_option=background_option,
+                    background_color=settings.get('backgroundColor'),
+                )
 
                 if not img:
                     logger.error("Failed to retrieve image from Immich")
@@ -168,19 +181,6 @@ class ImageAlbum(BasePlugin):
         if img is None:
             logger.error("Image is None after provider processing")
             raise RuntimeError("Failed to load image, please check logs.")
-
-        # Apply padding if requested (image was loaded at full size)
-        if use_padding:
-            logger.debug(f"Applying padding with {background_option} background")
-            if background_option == "blur":
-                img = pad_image_blur(img, dimensions)
-            else:
-                background_color = ImageColor.getcolor(
-                    settings.get('backgroundColor') or "white",
-                    img.mode
-                )
-                img = ImageOps.pad(img, dimensions, color=background_color, method=Image.Resampling.LANCZOS)
-        # else: loader already resized to fit with proper aspect ratio
 
         logger.info("=== Image Album Plugin: Image generation complete ===")
         return img

--- a/src/plugins/image_album/settings.html
+++ b/src/plugins/image_album/settings.html
@@ -14,13 +14,12 @@
 
 <div class="form-group">
     <div class="form-group">
-        <label for="padImage" class="form-label">Scale to Fit:</label>
-        <div class="toggle-container">
-            <input type="checkbox" id="padImage" name="padImage" class="toggle-checkbox" value="false">
-            <label for="padImage" class="toggle-label"></label>
-        </div>
-        <!-- Hidden input ensures 'true' is always sent when unchecked -->
-        <input type="hidden" name="padImage" value="true">
+        <label for="fitMode" class="form-label">Photo Fit:</label>
+        <select id="fitMode" name="fitMode" class="form-input">
+            <option value="contain">Scale to Fit</option>
+            <option value="cover">Fill Display</option>
+            <option value="auto">Auto</option>
+        </select>
     </div>
 
    <div class="form-group">
@@ -51,7 +50,7 @@
         if (loadPluginSettings) {
             document.getElementById('url').value = pluginSettings.url;
             document.getElementById('album').value = pluginSettings.album;
-            document.getElementById('padImage').checked = pluginSettings.padImage == 'false';
+            document.getElementById('fitMode').value = pluginSettings.fitMode;
             document.getElementById('randomize').checked = pluginSettings.randomize;
             document.getElementById('backgroundColor').value = pluginSettings.backgroundColor;
             backgroundOption = pluginSettings.backgroundOption || 'blur'

--- a/src/plugins/image_folder/image_folder.py
+++ b/src/plugins/image_folder/image_folder.py
@@ -1,10 +1,7 @@
 from plugins.base_plugin.base_plugin import BasePlugin
-from PIL import Image, ImageOps, ImageColor
 import logging
 import os
 import random
-
-from utils.image_utils import pad_image_blur
 
 logger = logging.getLogger(__name__)
 
@@ -53,31 +50,21 @@ class ImageFolder(BasePlugin):
         logger.info(f"Selected random image: {os.path.basename(image_url)}")
         logger.debug(f"Full path: {image_url}")
 
-        # Check padding options
-        use_padding = settings.get('padImage') == "true"
+        fit_mode = settings.get("fitMode", "cover")
         background_option = settings.get('backgroundOption', 'blur')
-        logger.debug(f"Settings: pad_image={use_padding}, background_option={background_option}")
+        logger.debug(f"Settings: fit_mode={fit_mode}, background_option={background_option}")
 
         try:
-            # Use adaptive loader for memory-efficient processing
-            # Load without auto-resize first to handle padding options
-            # Note: Loader automatically handles EXIF orientation correction
-            img = self.image_loader.from_file(image_url, dimensions, resize=False)
+            img = self.image_loader.from_file(
+                image_url,
+                dimensions,
+                fit_mode=fit_mode,
+                background_option=background_option,
+                background_color=settings.get('backgroundColor'),
+            )
 
             if not img:
                 raise RuntimeError("Failed to load image from file")
-
-            if use_padding:
-                logger.debug(f"Applying padding with {background_option} background")
-                if background_option == "blur":
-                    img = pad_image_blur(img, dimensions)
-                else:
-                    background_color = ImageColor.getcolor(settings.get('backgroundColor') or "white", img.mode)
-                    img = ImageOps.pad(img, dimensions, color=background_color, method=Image.Resampling.LANCZOS)
-            else:
-                # No padding requested, scale to fit dimensions (crop to preserve aspect ratio)
-                logger.debug(f"Scaling to fit dimensions: {dimensions[0]}x{dimensions[1]}")
-                img = ImageOps.fit(img, dimensions, method=Image.LANCZOS)
 
             return img
         except Exception as e:

--- a/src/plugins/image_folder/settings.html
+++ b/src/plugins/image_folder/settings.html
@@ -1,12 +1,11 @@
 <div class="form-group">
     <div class="form-group">
-        <label for="padImage" class="form-label">Scale to Fit:</label>
-        <div class="toggle-container">
-            <input type="checkbox" id="padImage" name="padImage" class="toggle-checkbox" value="false">
-            <label for="padImage" class="toggle-label"></label>
-        </div>
-        <!-- Hidden input ensures 'true' is always sent when unchecked -->
-        <input type="hidden" name="padImage" value="true">
+        <label for="fitMode" class="form-label">Photo Fit:</label>
+        <select id="fitMode" name="fitMode" class="form-input">
+            <option value="contain">Scale to Fit</option>
+            <option value="cover">Fill Display</option>
+            <option value="auto">Auto</option>
+        </select>
     </div>
 
     <div class="form-group">
@@ -33,7 +32,7 @@
         let backgroundOption = "blur"
         if (loadPluginSettings) {
             document.getElementById('folder_path').value = pluginSettings.folder_path;
-            document.getElementById('padImage').checked = pluginSettings.padImage == 'false';
+            document.getElementById('fitMode').value = pluginSettings.fitMode;
             document.getElementById('backgroundColor').value = pluginSettings.backgroundColor;
 
             backgroundOption = pluginSettings.backgroundOption;

--- a/src/plugins/image_upload/image_upload.py
+++ b/src/plugins/image_upload/image_upload.py
@@ -1,16 +1,23 @@
 from plugins.base_plugin.base_plugin import BasePlugin
-from PIL import Image, ImageOps, ImageColor
+from PIL import Image
 import logging
 import random
 import os
-
-from utils.image_utils import pad_image_blur
 
 logger = logging.getLogger(__name__)
 
 
 class ImageUpload(BasePlugin):
-    def open_image(self, img_index: int, image_locations: list, dimensions: tuple, resize: bool = True) -> Image:
+    def open_image(
+        self,
+        img_index: int,
+        image_locations: list,
+        dimensions: tuple,
+        *,
+        fit_mode: str | None = None,
+        background_option: str = "blur",
+        background_color: str | None = None,
+    ) -> Image:
         """
         Open image with adaptive loader for memory efficiency.
 
@@ -18,14 +25,21 @@ class ImageUpload(BasePlugin):
             img_index: Index of image to load
             image_locations: List of image paths
             dimensions: Target dimensions
-            resize: Whether to auto-resize (set False if manual padding needed)
+            fit_mode: Optional cover, contain, or automatic fitting mode
+            background_option: Background style for contained images
+            background_color: Solid background color when selected
         """
         if not image_locations:
             raise RuntimeError("No images provided.")
 
         try:
-            # Use adaptive loader for memory-efficient processing
-            image = self.image_loader.from_file(image_locations[img_index], dimensions, resize=resize)
+            image = self.image_loader.from_file(
+                image_locations[img_index],
+                dimensions,
+                fit_mode=fit_mode,
+                background_option=background_option,
+                background_color=background_color,
+            )
             if not image:
                 raise RuntimeError("Failed to load image from file")
             return image
@@ -60,35 +74,39 @@ class ImageUpload(BasePlugin):
             dimensions = dimensions[::-1]
             logger.debug(f"Vertical orientation detected, dimensions: {dimensions[0]}x{dimensions[1]}")
 
-        # Determine if we need manual padding
-        needs_padding = settings.get('padImage') == "true"
+        fit_mode = settings.get("fitMode", "cover")
         is_random = settings.get('randomize') == "true"
         background_option = settings.get('backgroundOption', 'blur')
+        background_color = settings.get('backgroundColor')
 
-        logger.debug(f"Settings: randomize={is_random}, pad_image={needs_padding}, background_option={background_option}")
+        logger.debug(f"Settings: randomize={is_random}, fit_mode={fit_mode}, background_option={background_option}")
 
-        # Load image (without auto-resize if padding needed)
         if is_random:
             img_index = random.randrange(0, len(image_locations))
             logger.info(f"Random mode: Selected image index {img_index}")
-            image = self.open_image(img_index, image_locations, dimensions, resize=not needs_padding)
+            image = self.open_image(
+                img_index,
+                image_locations,
+                dimensions,
+                fit_mode=fit_mode,
+                background_option=background_option,
+                background_color=background_color,
+            )
         else:
             logger.info(f"Sequential mode: Loading image index {img_index}")
-            image = self.open_image(img_index, image_locations, dimensions, resize=not needs_padding)
+            image = self.open_image(
+                img_index,
+                image_locations,
+                dimensions,
+                fit_mode=fit_mode,
+                background_option=background_option,
+                background_color=background_color,
+            )
             img_index = (img_index + 1) % len(image_locations)
             logger.debug(f"Next index will be: {img_index}")
 
         # Write the new index back to the device json
         settings['image_index'] = img_index
-
-        # Apply padding if requested
-        if needs_padding:
-            logger.debug(f"Applying padding with {background_option} background")
-            if background_option == "blur":
-                image = pad_image_blur(image, dimensions)
-            else:
-                background_color = ImageColor.getcolor(settings.get('backgroundColor') or "white", image.mode)
-                image = ImageOps.pad(image, dimensions, color=background_color, method=Image.Resampling.LANCZOS)
 
         logger.info("=== Image Upload Plugin: Image generation complete ===")
         return image

--- a/src/plugins/image_upload/settings.html
+++ b/src/plugins/image_upload/settings.html
@@ -1,12 +1,11 @@
 <div class="form-group">
     <div class="form-group">
-        <label for="padImage" class="form-label">Scale to Fit:</label>
-        <div class="toggle-container">
-            <input type="checkbox" id="padImage" name="padImage" class="toggle-checkbox" value="false">
-            <label for="padImage" class="toggle-label"></label>
-        </div>
-        <!-- Hidden input ensures 'true' is always sent when unchecked -->
-        <input type="hidden" name="padImage" value="true">
+        <label for="fitMode" class="form-label">Photo Fit:</label>
+        <select id="fitMode" name="fitMode" class="form-input">
+            <option value="contain">Scale to Fit</option>
+            <option value="cover">Fill Display</option>
+            <option value="auto">Auto</option>
+        </select>
     </div>
     <div class="form-group">
         <label for="randomize" class="form-label">Random Order:</label>
@@ -96,7 +95,7 @@
         const hiddenFileInputs = document.getElementById("hiddenFileInputs");
         let backgroundOption = "blur"
         if (loadPluginSettings) {
-            document.getElementById('padImage').checked = pluginSettings.padImage == 'false';
+            document.getElementById('fitMode').value = pluginSettings.fitMode;
             document.getElementById('randomize').checked = pluginSettings.randomize;
             document.getElementById('backgroundColor').value = pluginSettings.backgroundColor;
 

--- a/src/utils/image_loader.py
+++ b/src/utils/image_loader.py
@@ -6,9 +6,11 @@ Automatically uses memory-efficient strategies on low-RAM devices (Pi Zero)
 and high-performance strategies on capable devices (Pi 3/4).
 """
 
-from PIL import Image, ImageOps
+from PIL import Image, ImageColor, ImageOps
 from io import BytesIO
 from utils.http_client import get_http_session
+from utils.image_utils import pad_image_blur
+from utils.settings_migrations import IMAGE_FIT_MODES
 import logging
 import gc
 import psutil
@@ -60,7 +62,18 @@ class AdaptiveImageLoader:
     def __init__(self):
         self.is_low_resource = _is_low_resource_device()
 
-    def from_url(self, url, dimensions, timeout_ms=40000, resize=True, headers=None):
+    def from_url(
+        self,
+        url,
+        dimensions,
+        timeout_ms=40000,
+        resize=True,
+        headers=None,
+        *,
+        fit_mode=None,
+        background_option="blur",
+        background_color="white",
+    ):
         """
         Load an image from a URL and optionally resize it.
 
@@ -70,18 +83,38 @@ class AdaptiveImageLoader:
             timeout_ms: Request timeout in milliseconds
             resize: Whether to resize the image (default True)
             headers: Optional dict of HTTP headers to include in request
+            fit_mode: Optional cover, contain, or auto fitting mode. When set,
+                this takes precedence over resize.
+            background_option: Background style for contained images (blur or color)
+            background_color: Background color when background_option is color
 
         Returns:
             PIL Image object resized to dimensions, or None on error
         """
         logger.debug(f"Loading image from URL: {url}")
+        fit_options = self._resolve_fit_options(
+            resize, fit_mode, background_option, background_color
+        )
 
-        if self.is_low_resource:
-            return self._load_from_url_lowmem(url, dimensions, timeout_ms, resize, headers)
-        else:
-            return self._load_from_url_fast(url, dimensions, timeout_ms, resize, headers)
+        return self._load_from_url(
+            url,
+            dimensions,
+            timeout_ms,
+            headers,
+            fit_options,
+            use_temp_file=self.is_low_resource,
+        )
 
-    def from_file(self, path, dimensions, resize=True):
+    def from_file(
+        self,
+        path,
+        dimensions,
+        resize=True,
+        *,
+        fit_mode=None,
+        background_option="blur",
+        background_color="white",
+    ):
         """
         Load an image from a local file and optionally resize it.
 
@@ -89,6 +122,10 @@ class AdaptiveImageLoader:
             path: Path to local image file
             dimensions: Target dimensions as (width, height)
             resize: Whether to resize the image (default True)
+            fit_mode: Optional cover, contain, or auto fitting mode. When set,
+                this takes precedence over resize.
+            background_option: Background style for contained images (blur or color)
+            background_color: Background color when background_option is color
 
         Returns:
             PIL Image object resized to dimensions, or None on error
@@ -99,16 +136,23 @@ class AdaptiveImageLoader:
             logger.error(f"File not found: {path}")
             return None
 
-        try:
-            if self.is_low_resource:
-                return self._load_from_file_lowmem(path, dimensions, resize)
-            else:
-                return self._load_from_file_fast(path, dimensions, resize)
-        except Exception as e:
-            logger.error(f"Error loading image from {path}: {e}")
-            return None
+        fit_options = self._resolve_fit_options(
+            resize, fit_mode, background_option, background_color
+        )
+        return self._load_from_file(
+            path, dimensions, fit_options, use_draft=self.is_low_resource
+        )
 
-    def from_bytesio(self, data, dimensions, resize=True):
+    def from_bytesio(
+        self,
+        data,
+        dimensions,
+        resize=True,
+        *,
+        fit_mode=None,
+        background_option="blur",
+        background_color="white",
+    ):
         """
         Load an image from BytesIO object and optionally resize it.
 
@@ -116,51 +160,107 @@ class AdaptiveImageLoader:
             data: BytesIO object containing image data
             dimensions: Target dimensions as (width, height)
             resize: Whether to resize the image (default True)
+            fit_mode: Optional cover, contain, or auto fitting mode. When set,
+                this takes precedence over resize.
+            background_option: Background style for contained images (blur or color)
+            background_color: Background color when background_option is color
 
         Returns:
             PIL Image object resized to dimensions, or None on error
         """
         logger.debug("Loading image from BytesIO")
+        fit_options = self._resolve_fit_options(
+            resize, fit_mode, background_option, background_color
+        )
 
         try:
-            img = Image.open(data)
-            original_size = img.size
-            original_pixels = original_size[0] * original_size[1]
-            logger.info(f"Loaded image: {original_size[0]}x{original_size[1]} ({img.mode} mode, {original_pixels/1_000_000:.1f}MP)")
-
-            if resize:
-                img = self._process_and_resize(img, dimensions, original_size)
-            else:
-                # Even without resizing, apply EXIF orientation correction
-                img = ImageOps.exif_transpose(img)
-                if img.size != original_size:
-                    logger.debug(f"EXIF orientation applied: {original_size[0]}x{original_size[1]} -> {img.size[0]}x{img.size[1]}")
-
-            return img
+            return self._open_and_finish(data, dimensions, fit_options)
         except Exception as e:
             logger.error(f"Error loading image from BytesIO: {e}")
             return None
 
-    # ========== LOW-RESOURCE IMPLEMENTATIONS ==========
+    def _open_and_finish(
+        self,
+        source,
+        dimensions,
+        fit_options,
+        *,
+        use_draft=False,
+        log_action="Loaded",
+    ):
+        """Open an image source and send it through the shared finishing pipeline."""
+        img = Image.open(source)
+        original_size = img.size
+        original_pixels = original_size[0] * original_size[1]
+        logger.info(f"{log_action} image: {original_size[0]}x{original_size[1]} ({img.mode} mode, {original_pixels/1_000_000:.1f}MP)")
 
-    def _load_from_url_lowmem(self, url, dimensions, timeout_ms, resize, headers=None):
-        """Low-memory URL loading using temp file + draft mode."""
+        if use_draft and fit_options is not None:
+            img.draft('RGB', (dimensions[0] * 2, dimensions[1] * 2))
+            logger.debug("Draft mode applied - PIL will decode at reduced resolution")
+            img.load()
+            logger.debug(f"Image decoded: {img.size[0]}x{img.size[1]} (draft mode reduced from {original_size[0]}x{original_size[1]})")
+
+        if fit_options is None:
+            return self._apply_orientation(img, original_size)
+
+        return self._process_and_fit(img, dimensions, original_size, *fit_options)
+
+    def _load_from_file(self, path, dimensions, fit_options, use_draft=False):
+        """Load and process a local image with optional low-memory decoding."""
+        try:
+            return self._open_and_finish(
+                path,
+                dimensions,
+                fit_options,
+                use_draft=use_draft,
+            )
+        except MemoryError as e:
+            if use_draft:
+                logger.error(f"Out of memory while loading {path}: {e}")
+                logger.error("Try using a smaller image or enabling more swap space")
+                gc.collect()
+            else:
+                logger.error(f"Error loading image from {path}: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Error loading image from {path}: {e}")
+            return None
+
+    def _load_from_url(
+        self,
+        url,
+        dimensions,
+        timeout_ms,
+        headers,
+        fit_options,
+        use_temp_file=False,
+    ):
+        """Download and process an image using the selected resource strategy."""
         tmp_path = None
 
         try:
-            logger.debug("Using disk-based streaming (low-resource mode)")
-
-            # Merge provided headers with defaults
             request_headers = {**self.DEFAULT_HEADERS, **(headers or {})}
+            session = get_http_session()
+            response = session.get(
+                url,
+                timeout=timeout_ms / 1000,
+                stream=True,
+                headers=request_headers,
+            )
+            response.raise_for_status()
 
-            # Create temp file and stream download
+            if not use_temp_file:
+                logger.debug("Using in-memory processing (high-performance mode)")
+                return self._open_and_finish(
+                    BytesIO(response.content),
+                    dimensions,
+                    fit_options,
+                    log_action="Downloaded",
+                )
+
+            logger.debug("Using disk-based streaming (low-resource mode)")
             with tempfile.NamedTemporaryFile(delete=False, suffix='.jpg') as tmp:
                 tmp_path = tmp.name
-
-                session = get_http_session()
-                response = session.get(url, timeout=timeout_ms / 1000, stream=True, headers=request_headers)
-                response.raise_for_status()
-
                 downloaded_bytes = 0
                 for chunk in response.iter_content(chunk_size=8192):
                     if chunk:
@@ -169,12 +269,10 @@ class AdaptiveImageLoader:
 
                 logger.debug(f"Downloaded {downloaded_bytes / 1024:.1f}KB to temp file")
 
-            # Load from temp file with draft mode
-            return self._load_from_file_lowmem(tmp_path, dimensions, resize)
+            return self._load_from_file(
+                tmp_path, dimensions, fit_options, use_draft=True
+            )
 
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error downloading image from {url}: {e}")
-            return None
         except Exception as e:
             logger.error(f"Error processing image from {url}: {e}")
             return None
@@ -187,131 +285,76 @@ class AdaptiveImageLoader:
                 except Exception as e:
                     logger.warning(f"Could not delete temp file {tmp_path}: {e}")
 
-    def _load_from_file_lowmem(self, path, dimensions, resize):
-        """Low-memory file loading using draft mode."""
-        try:
-            img = Image.open(path)
-            original_size = img.size
-            original_pixels = original_size[0] * original_size[1]
-            logger.info(f"Loaded image: {original_size[0]}x{original_size[1]} ({img.mode} mode, {original_pixels/1_000_000:.1f}MP)")
-
-            if resize:
-                # Apply draft mode for massive memory savings during decode
-                img.draft('RGB', (dimensions[0] * 2, dimensions[1] * 2))
-                logger.debug(f"Draft mode applied - PIL will decode at reduced resolution")
-
-                # Force load with draft mode
-                img.load()
-                logger.debug(f"Image decoded: {img.size[0]}x{img.size[1]} (draft mode reduced from {original_size[0]}x{original_size[1]})")
-
-                img = self._process_and_resize(img, dimensions, original_size)
-            else:
-                # Even without resizing, apply EXIF orientation correction
-                img = ImageOps.exif_transpose(img)
-                if img.size != original_size:
-                    logger.debug(f"EXIF orientation applied: {original_size[0]}x{original_size[1]} -> {img.size[0]}x{img.size[1]}")
-
-            return img
-
-        except MemoryError as e:
-            logger.error(f"Out of memory while loading {path}: {e}")
-            logger.error("Try using a smaller image or enabling more swap space")
-            gc.collect()
-            return None
-        except Exception as e:
-            logger.error(f"Error loading image from {path}: {e}")
-            return None
-
-    # ========== HIGH-PERFORMANCE IMPLEMENTATIONS ==========
-
-    def _load_from_url_fast(self, url, dimensions, timeout_ms, resize, headers=None):
-        """High-performance URL loading using in-memory processing."""
-        try:
-            logger.debug("Using in-memory processing (high-performance mode)")
-
-            # Merge provided headers with defaults
-            request_headers = {**self.DEFAULT_HEADERS, **(headers or {})}
-
-            session = get_http_session()
-            response = session.get(url, timeout=timeout_ms / 1000, stream=True, headers=request_headers)
-            response.raise_for_status()
-
-            img = Image.open(BytesIO(response.content))
-            original_size = img.size
-            original_pixels = original_size[0] * original_size[1]
-            logger.info(f"Downloaded image: {original_size[0]}x{original_size[1]} ({img.mode} mode, {original_pixels/1_000_000:.1f}MP)")
-
-            if resize:
-                img = self._process_and_resize(img, dimensions, original_size)
-            else:
-                # Even without resizing, apply EXIF orientation correction
-                img = ImageOps.exif_transpose(img)
-                if img.size != original_size:
-                    logger.debug(f"EXIF orientation applied: {original_size[0]}x{original_size[1]} -> {img.size[0]}x{img.size[1]}")
-
-            return img
-
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error downloading image from {url}: {e}")
-            return None
-        except Exception as e:
-            logger.error(f"Error processing image from {url}: {e}")
-            return None
-
-    def _load_from_file_fast(self, path, dimensions, resize):
-        """High-performance file loading using in-memory processing."""
-        try:
-            img = Image.open(path)
-            original_size = img.size
-            original_pixels = original_size[0] * original_size[1]
-            logger.info(f"Loaded image: {original_size[0]}x{original_size[1]} ({img.mode} mode, {original_pixels/1_000_000:.1f}MP)")
-
-            if resize:
-                img = self._process_and_resize(img, dimensions, original_size)
-            else:
-                # Even without resizing, apply EXIF orientation correction
-                img = ImageOps.exif_transpose(img)
-                if img.size != original_size:
-                    logger.debug(f"EXIF orientation applied: {original_size[0]}x{original_size[1]} -> {img.size[0]}x{img.size[1]}")
-
-            return img
-
-        except Exception as e:
-            logger.error(f"Error loading image from {path}: {e}")
-            return None
-
     # ========== SHARED PROCESSING LOGIC ==========
 
-    def _process_and_resize(self, img, dimensions, original_size):
-        """
-        Process and resize image with device-appropriate optimizations.
+    def _resolve_fit_options(
+        self, resize, fit_mode, background_option, background_color
+    ):
+        """Map the legacy resize flag and explicit fit mode to one pipeline."""
+        if fit_mode is None:
+            if not resize:
+                return None
+            fit_mode = "cover"
 
-        Args:
-            img: PIL Image object
-            dimensions: Target dimensions (width, height)
-            original_size: Original image size for logging
+        return fit_mode, background_option, background_color
 
-        Returns:
-            Processed and resized PIL Image
-        """
-        # Apply EXIF orientation correction first (before any processing)
-        # This handles images from cameras/phones that store rotation in EXIF metadata
-        # Safe to call on any image - returns unchanged if no EXIF data present
+    def _apply_orientation(self, img, original_size):
+        """Apply EXIF orientation without otherwise modifying the image."""
         img = ImageOps.exif_transpose(img)
         if img.size != original_size:
             logger.debug(f"EXIF orientation applied: {original_size[0]}x{original_size[1]} -> {img.size[0]}x{img.size[1]}")
-        
+
+        return img
+
+    def _prepare_image(self, img, original_size):
+        """Apply shared orientation and color-mode preparation."""
+        img = self._apply_orientation(img, original_size)
+
         # Convert to RGB if necessary (removes alpha channel, saves memory)
         # E-ink displays don't need alpha channel anyway
         if img.mode in ('RGBA', 'LA', 'P'):
             logger.debug(f"Converting image from {img.mode} to RGB")
             img = img.convert('RGB')
 
-        # Choose processing strategy based on device capabilities
-        if self.is_low_resource:
-            img = self._resize_low_resource(img, dimensions)
+        return img
+
+    def _process_and_fit(
+        self,
+        img,
+        dimensions,
+        original_size,
+        fit_mode,
+        background_option,
+        background_color,
+    ):
+        """Apply cover, contain, or orientation-aware automatic fitting."""
+        dimensions = tuple(map(int, dimensions))
+        img = self._prepare_image(img, original_size)
+
+        if fit_mode not in IMAGE_FIT_MODES:
+            fit_mode = "cover"
+
+        if fit_mode == "auto":
+            image_is_landscape = img.width >= img.height
+            display_is_landscape = dimensions[0] >= dimensions[1]
+            fit_mode = "cover" if image_is_landscape == display_is_landscape else "contain"
+
+        logger.debug(f"Applying {fit_mode} image fitting")
+        if fit_mode == "cover":
+            if self.is_low_resource:
+                img = self._resize_low_resource(img, dimensions)
+            else:
+                img = self._resize_high_performance(img, dimensions)
+        elif background_option == "blur":
+            img = pad_image_blur(img, dimensions)
         else:
-            img = self._resize_high_performance(img, dimensions)
+            color = ImageColor.getcolor(background_color or "white", img.mode)
+            img = ImageOps.pad(
+                img,
+                dimensions,
+                method=Image.Resampling.LANCZOS,
+                color=color,
+            )
 
         logger.info(f"Image processing complete: {dimensions[0]}x{dimensions[1]}")
         return img
@@ -357,4 +400,3 @@ class AdaptiveImageLoader:
         logger.debug(f"Resizing from {img.size[0]}x{img.size[1]} to {dimensions[0]}x{dimensions[1]}")
 
         return ImageOps.fit(img, dimensions, method=Image.LANCZOS)
-

--- a/src/utils/settings_migrations.py
+++ b/src/utils/settings_migrations.py
@@ -1,0 +1,28 @@
+IMAGE_FIT_MODES = {"cover", "contain", "auto"}
+IMAGE_FIT_PLUGINS = {"image_album", "image_folder", "image_upload"}
+
+
+def _migrate_image_fit(settings):
+    fit_mode = settings.get("fitMode")
+    if fit_mode not in IMAGE_FIT_MODES:
+        fit_mode = "contain" if settings.get("padImage") == "true" else "cover"
+
+    settings["fitMode"] = fit_mode
+    settings.pop("padImage", None)
+
+
+PLUGIN_SETTING_MIGRATIONS = {
+    plugin_id: (_migrate_image_fit,) for plugin_id in IMAGE_FIT_PLUGINS
+}
+
+
+def migrate_plugin_settings(plugin_id, settings):
+    """Apply registered migrations before plugin settings are used."""
+    migrations = PLUGIN_SETTING_MIGRATIONS.get(plugin_id)
+    if not migrations:
+        return settings
+
+    migrated = dict(settings or {})
+    for migration in migrations:
+        migration(migrated)
+    return migrated

--- a/tests/test_smart_photo_fitting.py
+++ b/tests/test_smart_photo_fitting.py
@@ -1,0 +1,272 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from model import PluginInstance
+from utils.image_loader import AdaptiveImageLoader
+from utils.image_utils import resize_image
+from utils.settings_migrations import migrate_plugin_settings
+
+
+def load_fitted_image(
+    image_size,
+    display_size,
+    fit_mode,
+    background_option="color",
+    background_color="#ffffff",
+):
+    data = BytesIO()
+    Image.new("RGB", image_size, "red").save(data, format="PNG")
+    data.seek(0)
+
+    loader = AdaptiveImageLoader()
+    loader.is_low_resource = False
+    return loader.from_bytesio(
+        data,
+        display_size,
+        fit_mode=fit_mode,
+        background_option=background_option,
+        background_color=background_color,
+    )
+
+
+@pytest.mark.parametrize(
+    "image_size,display_size,expects_padding",
+    [
+        ((400, 800), (800, 480), True),
+        ((800, 400), (800, 480), False),
+        ((600, 600), (800, 480), False),
+        ((800, 400), (480, 800), True),
+        ((400, 800), (480, 800), False),
+    ],
+)
+def test_smart_fit_uses_orientation_to_choose_contain_or_cover(
+    image_size, display_size, expects_padding
+):
+    result = load_fitted_image(
+        image_size,
+        display_size,
+        "auto",
+    )
+
+    assert result.size == display_size
+    assert (result.getpixel((0, 0)) == (255, 255, 255)) is expects_padding
+    assert result.getpixel((display_size[0] // 2, display_size[1] // 2)) == (255, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "settings,expected",
+    [
+        ({"fitMode": "cover"}, "cover"),
+        ({"fitMode": "contain"}, "contain"),
+        ({"fitMode": "auto"}, "auto"),
+        ({"fitMode": "auto", "padImage": "true"}, "auto"),
+        ({"fitMode": "cover", "padImage": "true"}, "cover"),
+        ({"padImage": "false"}, "cover"),
+        ({"padImage": "true"}, "contain"),
+        ({}, "cover"),
+    ],
+)
+def test_fit_mode_supports_new_and_legacy_settings(settings, expected):
+    migrated = migrate_plugin_settings("image_upload", settings)
+    assert migrated["fitMode"] == expected
+
+
+@pytest.mark.parametrize(
+    "settings,expected",
+    [
+        ({"padImage": "true"}, "contain"),
+        ({"padImage": "false"}, "cover"),
+        ({"fitMode": "auto", "padImage": "true"}, "auto"),
+    ],
+)
+def test_legacy_fit_settings_are_converted_and_removed(settings, expected):
+    migrated = migrate_plugin_settings("image_upload", settings)
+    assert migrated["fitMode"] == expected
+    assert "padImage" not in migrated
+
+
+def test_migrated_settings_serialize_without_pad_image():
+    plugin_instance = PluginInstance(
+        plugin_id="image_upload",
+        name="Photos",
+        settings={"padImage": "true"},
+        refresh={"interval": 3600},
+    )
+
+    saved_settings = plugin_instance.to_dict()["plugin_settings"]
+    assert saved_settings["fitMode"] == "contain"
+    assert "padImage" not in saved_settings
+
+
+def test_replacing_instance_settings_uses_the_central_migration():
+    plugin_instance = PluginInstance(
+        plugin_id="image_folder",
+        name="Photos",
+        settings={"fitMode": "cover"},
+        refresh={"interval": 3600},
+    )
+
+    plugin_instance.settings = {"fitMode": "auto", "padImage": "true"}
+
+    assert plugin_instance.settings == {"fitMode": "auto"}
+
+
+def test_unrelated_plugin_settings_are_not_modified():
+    settings = {"padImage": "true"}
+
+    migrated = migrate_plugin_settings("weather", settings)
+
+    assert migrated is settings
+    assert migrated == {"padImage": "true"}
+
+
+def test_existing_cover_and_contain_modes_remain_explicit():
+    covered = load_fitted_image((400, 800), (800, 480), "cover")
+    contained = load_fitted_image(
+        (800, 400),
+        (800, 480),
+        "contain",
+    )
+
+    assert covered.getpixel((0, 0)) == (255, 0, 0)
+    assert contained.getpixel((0, 0)) == (255, 255, 255)
+
+
+def test_fit_mode_takes_precedence_over_legacy_resize_flag():
+    data = BytesIO()
+    Image.new("RGB", (400, 800), "red").save(data, format="PNG")
+    data.seek(0)
+
+    loader = AdaptiveImageLoader()
+    loader.is_low_resource = False
+    result = loader.from_bytesio(
+        data,
+        (800, 480),
+        resize=False,
+        fit_mode="contain",
+        background_option="color",
+        background_color="#ffffff",
+    )
+
+    assert result.size == (800, 480)
+    assert result.getpixel((0, 0)) == (255, 255, 255)
+
+
+@pytest.mark.parametrize(
+    "resize,expected_size",
+    [
+        (True, (800, 480)),
+        (False, (400, 800)),
+    ],
+)
+def test_legacy_resize_interface_is_preserved(resize, expected_size):
+    data = BytesIO()
+    Image.new("RGB", (400, 800), "red").save(data, format="PNG")
+    data.seek(0)
+
+    loader = AdaptiveImageLoader()
+    loader.is_low_resource = False
+    result = loader.from_bytesio(data, (800, 480), resize=resize)
+
+    assert result.size == expected_size
+
+
+@pytest.mark.parametrize("is_low_resource", [False, True])
+def test_file_loader_applies_auto_fit_on_all_device_types(tmp_path, is_low_resource):
+    image_path = tmp_path / "portrait.jpg"
+    Image.new("RGB", (400, 800), "red").save(image_path)
+
+    loader = AdaptiveImageLoader()
+    loader.is_low_resource = is_low_resource
+    result = loader.from_file(
+        image_path,
+        (800, 480),
+        fit_mode="auto",
+        background_option="color",
+        background_color="#ffffff",
+    )
+
+    assert result.size == (800, 480)
+    assert result.getpixel((0, 0)) == (255, 255, 255)
+
+
+@pytest.mark.parametrize("is_low_resource", [False, True])
+def test_url_loader_applies_auto_fit_on_all_device_types(monkeypatch, is_low_resource):
+    data = BytesIO()
+    Image.new("RGB", (400, 800), "red").save(data, format="PNG")
+    image_bytes = data.getvalue()
+
+    class Response:
+        content = image_bytes
+
+        def raise_for_status(self):
+            pass
+
+        def iter_content(self, chunk_size):
+            yield image_bytes
+
+    class Session:
+        def get(self, *args, **kwargs):
+            return Response()
+
+    monkeypatch.setattr("utils.image_loader.get_http_session", lambda: Session())
+
+    loader = AdaptiveImageLoader()
+    loader.is_low_resource = is_low_resource
+    result = loader.from_url(
+        "https://example.com/portrait.png",
+        (800, 480),
+        fit_mode="auto",
+        background_option="color",
+        background_color="#ffffff",
+    )
+
+    assert result.size == (800, 480)
+    assert result.getpixel((0, 0)) == (255, 255, 255)
+
+
+def test_url_loader_returns_none_when_download_fails(monkeypatch):
+    class Session:
+        def get(self, *args, **kwargs):
+            raise RuntimeError("download failed")
+
+    monkeypatch.setattr("utils.image_loader.get_http_session", lambda: Session())
+
+    loader = AdaptiveImageLoader()
+    assert loader.from_url("https://example.com/missing.jpg", (800, 480)) is None
+
+
+def test_display_resize_preserves_legacy_cover_behavior():
+    result = resize_image(Image.new("RGB", (400, 800), "red"), (800, 480))
+
+    assert result.size == (800, 480)
+    assert result.getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_keep_width_remains_unchanged():
+    result = resize_image(
+        Image.new("RGB", (400, 800), "red"),
+        (800, 480),
+        image_settings=["keep-width"],
+    )
+
+    assert result.size == (800, 480)
+    assert result.getpixel((0, 0)) == (255, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "resize_method",
+    ["_resize_high_performance", "_resize_low_resource"],
+)
+def test_adaptive_loader_preserves_legacy_cover_behavior(resize_method):
+    loader = AdaptiveImageLoader()
+
+    result = getattr(loader, resize_method)(
+        Image.new("RGB", (400, 800), "red"),
+        (800, 480),
+    )
+
+    assert result.size == (800, 480)
+    assert result.getpixel((0, 0)) == (255, 0, 0)


### PR DESCRIPTION
## Summary

Adds an opt-in `Auto` photo-fitting mode alongside the existing `Fill Display` and `Scale to Fit` options.

Auto fitting evaluates each source image independently:

- When the image and display orientations match, the image fills the display using Cover.
- When their orientations differ, the complete image is shown using Contain.
- Contained images retain the existing blurred or solid-colour background options.

## Implementation

- Centralizes Cover, Contain, and Auto processing in `AdaptiveImageLoader`.
- Preserves the existing `resize=True` and `resize=False` interfaces for all existing plugins.
- Adds Auto to Image Album, Image Folder, and Image Upload.
- Migrates legacy `padImage` settings centrally to `fitMode`.

## Compatibility

Existing behaviour remains the default:

- `resize=True` continues to use Cover.
- `resize=False` continues to load without final display sizing.
- Existing Cover and Contain selections remain explicit.
- Auto is opt-in.
- Legacy `padImage=true` becomes Contain.
- Legacy `padImage=false` becomes Cover.

## Validation

- 57 automated tests pass.
- File, URL, and byte-stream loading are covered.
- Normal and low-memory device paths are covered.
- Cover, Contain, Auto, and legacy resize behaviour are covered.
- All 20 registered plugins load successfully.