### PR TITLE
Restore Unsplash API request timeout

### DIFF
--- a/src/plugins/unsplash/unsplash.py
+++ b/src/plugins/unsplash/unsplash.py
@@ -3,6 +3,7 @@ from utils.image_loader import _is_low_resource_device
 from utils.http_client import get_http_session
 import logging
 import random
+import requests
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ class Unsplash(BasePlugin):
         try:
             logger.debug("Fetching image from Unsplash API...")
             session = get_http_session()
-            response = session.get(url, params=params)
+            response = session.get(url, params=params, timeout=30)
             response.raise_for_status()
             data = response.json()
 


### PR DESCRIPTION
## Summary

Restore the 30-second timeout for Unsplash API requests while continuing to use InkyPi's shared HTTP session.

This also restores the `requests` import required by the existing `requests.exceptions.RequestException` handler.

## Problem

PR #545 added explicit 30-second request timeouts to prevent network requests from hanging indefinitely.

PR #427 later migrated the Unsplash plugin to the shared HTTP session, changing:

```python
requests.get(url, params=params, timeout=30)
```

to:

```python
session.get(url, params=params)
```

That unintentionally removed the timeout. It also removed the `requests` import even though the existing exception handler still references `requests.exceptions.RequestException`.

Without an explicit timeout, an Unsplash refresh can remain blocked when connectivity, DNS, or routing is interrupted. Because playlist refreshes run on a single background thread, this can prevent subsequent scheduled updates from running.

## Changes

* Add `timeout=30` to the Unsplash API request.
* Restore `import requests` for the existing exception handler.
* Retain the shared HTTP session and connection pooling introduced by PR #427.

When the request times out, Requests raises a `Timeout` exception, which inherits from `RequestException`. The existing handler therefore logs the failure and raises `RuntimeError`, allowing the refresh task to handle the failed attempt instead of remaining blocked.

## Testing

* `python3 -m py_compile src/plugins/unsplash/unsplash.py`
* `git diff --check`

Both checks completed successfully against the current `main` branch with this patch applied.

## Related pull requests

* #545 — originally added request timeouts to prevent hangs.
* #427 — unintentionally removed the Unsplash timeout during the shared-session refactor.
* #692 — restores the missing `requests` import, but its Unsplash API requests still lack explicit timeouts.
