### PR TITLE
Accept a driver path for the -W install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ To install InkyPi, follow these steps:
     sudo bash install/install.sh -W epd7in3f
     ```
 
+    Some models are not published in the [common driver directory](https://github.com/waveshareteam/e-Paper/tree/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd) and only ship under `E-paper_Separate_Program`. For those, pass the path to the driver within the [waveshareteam/e-Paper](https://github.com/waveshareteam/e-Paper) repository instead of the bare model name:
+    ```bash
+    sudo bash install/install.sh -W E-paper_Separate_Program/3.6inch_e-Paper_E/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in6e.py
+    ```
+
 
 After the installation is complete, the script will prompt you to reboot your Raspberry Pi. Once rebooted, the display will update to show the InkyPi splash screen.
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -9,6 +9,11 @@
 #        -W <waveshare_device> (optional) Install for a Waveshare device,
 #                               specifying the device model type, e.g. epd7in3e.
 #
+#                               Alternatively the path to the driver within the
+#                               waveshareteam/e-Paper repository can be given,
+#                               e.g. E-paper_Separate_Program/3.6inch_e-Paper_E/
+#                               RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in6e.py
+#
 #                               If not specified then the Pimoroni Inky display
 #                               is assumed.
 # =============================================================================
@@ -48,11 +53,45 @@ PIP_REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
 WS_TYPE=""
 WS_REQUIREMENTS_FILE="$SCRIPT_DIR/ws-requirements.txt"
 
+# Where the driver is fetched from in the Waveshare e-Paper repository.  Most
+# models live in the common driver directory, but models that are only
+# published under E-paper_Separate_Program can override WS_DRIVER_DIR by
+# passing a repo relative path to -W (see resolve_waveshare_type).
+WS_DRIVER_REPO="waveshareteam/e-Paper"
+WS_DRIVER_BRANCH="master"
+WS_DRIVER_DEFAULT_DIR="RaspberryPi_JetsonNano/python/lib/waveshare_epd"
+WS_DRIVER_DIR="$WS_DRIVER_DEFAULT_DIR"
+
+# Work out the screen type, and where its driver lives, from the -W argument.
+#
+# The argument is either a bare model name, e.g. epd7in3e, or the path to the
+# driver within the waveshareteam/e-Paper repository, e.g.
+# E-paper_Separate_Program/3.6inch_e-Paper_E/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in6e.py
+#
+# The path form is needed for the models that are not published in the common
+# driver directory.  Either way WS_TYPE ends up as the bare module name, e.g.
+# epd3in6e, as that is what is written to device.json and imported at runtime.
+resolve_waveshare_type() {
+    local arg=${1#/}
+
+    if [[ $arg == */* ]]; then
+        WS_DRIVER_DIR=${arg%/*}
+        arg=${arg##*/}
+    fi
+
+    WS_TYPE=${arg%.py}
+
+    if [[ -z $WS_TYPE ]]; then
+        echo "Option -W requires the model type of the Waveshare screen." >&2
+        exit 1
+    fi
+}
+
 # Parse the arguments, looking for the -W option.
 parse_arguments() {
     while getopts ":W:" opt; do
         case $opt in
-            W) WS_TYPE=$OPTARG
+            W) resolve_waveshare_type "$OPTARG"
                 echo "Optional parameter WS is set for Waveshare support.  Screen type is: $WS_TYPE"
                 ;;
             \?) echo "Invalid option: -$OPTARG." >&2
@@ -78,7 +117,8 @@ fetch_waveshare_driver() {
 
   DRIVER_DEST="$SRC_PATH/display/waveshare_epd"
   DRIVER_FILE="$DRIVER_DEST/$WS_TYPE.py"
-  DRIVER_URL="https://raw.githubusercontent.com/waveshareteam/e-Paper/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/$WS_TYPE.py"
+  DRIVER_BASE_URL="https://raw.githubusercontent.com/$WS_DRIVER_REPO/$WS_DRIVER_BRANCH/$WS_DRIVER_DIR"
+  DRIVER_URL="$DRIVER_BASE_URL/$WS_TYPE.py"
 
   # Attempt to download the file
   if [ -f "$DRIVER_FILE" ]; then
@@ -86,19 +126,27 @@ fetch_waveshare_driver() {
   elif curl --silent --fail -o "$DRIVER_FILE" "$DRIVER_URL"; then
     echo_success "\tWaveshare driver '$WS_TYPE.py' successfully downloaded to $DRIVER_FILE"
   else
-    echo_error "ERROR: Failed to download Waveshare driver '$WS_TYPE.py'."
+    rm -f "$DRIVER_FILE"
+    echo_error "ERROR: Failed to download Waveshare driver '$WS_TYPE.py' from:"
+    echo_error "$DRIVER_URL"
     echo_error "Ensure the model name is correct and exists at:"
-    echo_error "https://github.com/waveshareteam/e-Paper/tree/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd"
+    echo_error "https://github.com/$WS_DRIVER_REPO/tree/$WS_DRIVER_BRANCH/$WS_DRIVER_DIR"
     exit 1
   fi
 
+  # Prefer the epdconfig.py that sits alongside the driver, as the separate
+  # programs ship their own copy, falling back to the common one.
   EPD_CONFIG_FILE="$DRIVER_DEST/epdconfig.py"
-  EPD_CONFIG_URL="https://raw.githubusercontent.com/waveshareteam/e-Paper/refs/heads/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epdconfig.py"
+  EPD_CONFIG_URL="$DRIVER_BASE_URL/epdconfig.py"
+  EPD_CONFIG_FALLBACK_URL="https://raw.githubusercontent.com/$WS_DRIVER_REPO/$WS_DRIVER_BRANCH/$WS_DRIVER_DEFAULT_DIR/epdconfig.py"
   if [ -f "$EPD_CONFIG_FILE" ]; then
     echo_success "\tWaveshare epdconfig file already exists at $EPD_CONFIG_FILE"
   elif curl --silent --fail -o "$EPD_CONFIG_FILE" "$EPD_CONFIG_URL"; then
     echo_success "\tWaveshare epdconfig file successfully downloaded to $EPD_CONFIG_FILE"
+  elif curl --silent --fail -o "$EPD_CONFIG_FILE" "$EPD_CONFIG_FALLBACK_URL"; then
+    echo_success "\tWaveshare epdconfig file successfully downloaded to $EPD_CONFIG_FILE"
   else
+    rm -f "$EPD_CONFIG_FILE"
     echo_error "ERROR: Failed to download Waveshare epdconfig file."
     exit 1
   fi


### PR DESCRIPTION
## Problem

`fetch_waveshare_driver` always builds the download URL from the common driver
directory:

```
https://raw.githubusercontent.com/waveshareteam/e-Paper/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/$WS_TYPE.py
```

Some models are not published there. The 3.6inch e-Paper (E), for example, only
ships under `E-paper_Separate_Program`, so `-W epd3in6e` fails the download and
the install aborts with "Ensure the model name is correct".

## Change

`-W` now also accepts the path to the driver within the waveshareteam/e-Paper
repository:

```bash
sudo bash install/install.sh -W E-paper_Separate_Program/3.6inch_e-Paper_E/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd3in6e.py
```

A new `resolve_waveshare_type()` splits that into the directory to fetch from
and the bare module name, so `WS_TYPE` ends up as `epd3in6e` — which is what
`update_config` writes to `device.json` and what `WaveshareDisplay` imports at
runtime. A leading `/` and a missing `.py` are both tolerated. A bare model
name takes the default directory and behaves exactly as before.

`epdconfig.py` is now fetched from the same directory as the driver, since the
separate programs ship their own copy, falling back to the common one if that
directory has none.

Also: a failed download no longer leaves the empty file behind that
`curl --fail -o` creates. Otherwise the `[ -f "$EPD_CONFIG_FILE" ]` check on the
next run reports it as "already exists" and silently skips the download.

## Testing

`bash -n install/install.sh` passes, and `resolve_waveshare_type` was exercised
directly:

| `-W` argument | `WS_TYPE` | driver URL |
|---|---|---|
| `epd7in3f` | `epd7in3f` | common dir (unchanged) |
| `epd3in6e.py` | `epd3in6e` | common dir |
| `E-paper_Separate_Program/.../waveshare_epd/epd3in6e.py` | `epd3in6e` | separate-program dir |
| leading `/`, no `.py` | `epd3in6e` | separate-program dir |

The URLs built for `epd3in6e.py`, its sibling `epdconfig.py`, and the unchanged
`epd7in3f.py` path all return 200. The installer has not been run end to end on
a Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)