### PR TITLE
Update Inky library to 2.4.0 to support newer hardware

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -1,6 +1,6 @@
 flask==3.1.2
 python-dotenv==1.2.1
-inky==2.3.0
+inky==2.4.0
 requests==2.32.5
 urllib3==2.6.3
 werkzeug==3.1.5


### PR DESCRIPTION
Pimoroni have introduced new Spectra 6 hardware (produced April 2026 onwards) for their Inky Impression 7.3" model:

https://shop.pimoroni.com/products/inky-impression?variant=55186435244411

> ** 7.3" Inky Impressions made from April 2026 onwards use a new 'AC waveform' Spectra 6 display panel. These panels have a slightly longer core refresh time than previous panels, in exchange for some colour improvements and reduced ghosting.

This new hardware requires the Inky Python library to be at least version 2.4.0 to be recognised automatically:

https://github.com/pimoroni/inky/releases/tag/v2.4.0
https://pypi.org/project/inky/

This PR bumps the version of Inky installed by the InkyPi install (and update) script to support the new hardware.

Note: I don't have one of the newer models to test this fixes the auto detect issue, but on my Inky Impression 7.3" this change worked fine.